### PR TITLE
Release process update + small telemetry fix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Publish Desktop
+name: Publish release
 on:
   release:
     types: [prereleased]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,7 +120,7 @@ jobs:
         if: matrix.settings.host != 'windows-latest'
         run: |
           BIN_NAME=devpod-cli-${{ matrix.settings.target }}
-          GOOS=${{ matrix.settings.os }} GOARCH=${{ matrix.settings.arch }} go build -ldflags "-s -w" -o "test/$BIN_NAME"
+          GOOS=${{ matrix.settings.os }} GOARCH=${{ matrix.settings.arch }} go build -ldflags "-s -w -X github.com/loft-sh/devpod/pkg/version.version=${process.env.GITHUB_REF_NAME} -X github.com/loft-sh/devpod/pkg/telemetry.telemetryPrivateKey=${{ secrets.DEVPOD_TELEMETRY_PRIVATE_KEY }}" -o "test/$BIN_NAME"
           cp "test/$BIN_NAME" "desktop/src-tauri/bin/$BIN_NAME"
           ls desktop/src-tauri/bin
 
@@ -132,7 +132,7 @@ jobs:
           set GOARCH=${{ matrix.settings.arch }}
           set BIN_NAME=devpod-cli-${{ matrix.settings.target }}.exe
 
-          go build -ldflags "-s -w" -o "test\%BIN_NAME%"
+          go build -ldflags "-s -w -X github.com/loft-sh/devpod/pkg/version.version=${process.env.GITHUB_REF_NAME} -X github.com/loft-sh/devpod/pkg/telemetry.telemetryPrivateKey=${{ secrets.DEVPOD_TELEMETRY_PRIVATE_KEY }}" -o "test\%BIN_NAME%"
 
           xcopy /F /Y "test\%BIN_NAME%" desktop\src-tauri\bin\*
 

--- a/pkg/telemetry/collect.go
+++ b/pkg/telemetry/collect.go
@@ -94,15 +94,16 @@ func (d *DefaultCollector) RecordStartEvent(provider string) {
 			cmd = d.command.CommandPath()
 		}
 
+		ts := time.Now().UnixMicro()
 		recordEvent(d.tokenGenerator, &types.TelemetryRequest{
 			EventType: types.EventCommandStarted,
 			Event: types.CMDStartedEvent{
-				Timestamp:   int(time.Now().UnixMicro()),
+				Timestamp:   ts,
 				ExecutionID: d.executionID,
 				Command:     cmd,
 				Provider:    provider,
 			},
-			InstanceProperties: d.getInstanceProperties(d.command),
+			InstanceProperties: d.getInstanceProperties(d.command, d.executionID, ts),
 		})
 	})
 }
@@ -126,10 +127,11 @@ func (d *DefaultCollector) RecordEndEvent(err error) {
 		cmdErr = err.Error()
 	}
 
+	ts := time.Now().UnixMicro()
 	recordEvent(d.tokenGenerator, &types.TelemetryRequest{
 		EventType: types.EventCommandFinished,
 		Event: types.CMDFinishedEvent{
-			Timestamp:      int(time.Now().UnixMicro()),
+			Timestamp:      ts,
 			ExecutionID:    d.executionID,
 			Command:        cmd,
 			Provider:       d.provider,
@@ -137,7 +139,7 @@ func (d *DefaultCollector) RecordEndEvent(err error) {
 			ProcessingTime: int(time.Since(d.startTime).Microseconds()),
 			Errors:         cmdErr,
 		},
-		InstanceProperties: d.getInstanceProperties(d.command),
+		InstanceProperties: d.getInstanceProperties(d.command, d.executionID, ts),
 	})
 }
 

--- a/pkg/telemetry/helpers.go
+++ b/pkg/telemetry/helpers.go
@@ -20,13 +20,15 @@ const (
 	hashingKey = "2f1uR7n8ryzFEaAm87Ec"
 )
 
-func (d *DefaultCollector) getInstanceProperties(command *cobra.Command) types.InstanceProperties {
+func (d *DefaultCollector) getInstanceProperties(command *cobra.Command, executionID string, ts int64) types.InstanceProperties {
 	p := types.InstanceProperties{
-		UID:     getUID(),
-		Arch:    runtime.GOARCH,
-		OS:      runtime.GOOS,
-		Version: getVersion(),
-		Flags:   getFlags(command),
+		Timestamp:   ts,
+		ExecutionID: executionID,
+		UID:         getUID(),
+		Arch:        runtime.GOARCH,
+		OS:          runtime.GOOS,
+		Version:     getVersion(),
+		Flags:       getFlags(command),
 	}
 
 	return p

--- a/pkg/telemetry/types/types.go
+++ b/pkg/telemetry/types/types.go
@@ -21,7 +21,7 @@ type Version struct {
 }
 
 type InstanceProperties struct {
-	Timestamp   int     `json:"timestamp,omitempty"`
+	Timestamp   int64   `json:"timestamp,omitempty"`
 	ExecutionID string  `json:"executionID,omitempty"`
 	UID         string  `json:"uid,omitempty"`
 	Arch        string  `json:"arch,omitempty"`
@@ -41,7 +41,7 @@ type Event interface{}
 
 type CMDStartedEvent struct {
 	// Timestamp represents Unix timestampt in microseconds
-	Timestamp       int    `json:"timestamp,omitempty"`
+	Timestamp       int64  `json:"timestamp,omitempty"`
 	ExecutionID     string `json:"executionID,omitempty"`
 	Command         string `json:"command,omitempty"`
 	Provider        string `json:"provider,omitempty"`
@@ -50,7 +50,7 @@ type CMDStartedEvent struct {
 
 type CMDFinishedEvent struct {
 	// Time represents Unix timestampt in microseconds
-	Timestamp       int    `json:"timestamp,omitempty"`
+	Timestamp       int64  `json:"timestamp,omitempty"`
 	ExecutionID     string `json:"executionID,omitempty"`
 	Command         string `json:"command,omitempty"`
 	Provider        string `json:"provider,omitempty"`


### PR DESCRIPTION
Small telemetry fix to fill in missing values in the `InstanceProperties` and set concrete `int64` type instead of `int`.

The release workflow has been updated to inject correct value for the `pkg/version.version` variable and also correct telemetry certificate.