### PR TITLE
fix: linux transparency issue

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,12 +167,29 @@ jobs:
         working-directory: "./desktop"
 
       - name: Build Desktop App
-        if: matrix.settings.host != 'windows-latest' && matrix.settings.cli_only == false
+        if: matrix.settings.host == 'ubuntu-latest' && matrix.settings.cli_only == false
         uses: tauri-apps/tauri-action@v0.4.0
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           projectPath: "./desktop"
-          args: " --target ${{ matrix.settings.target }}"
+          args: "--config src-tauri/tauri-linux.conf.json --target ${{ matrix.settings.target }}"
+          includeUpdaterJson: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          # AppImage Signing:
+          SIGN: ${{ secrets.APP_IMAGE_SIGN }}
+          SIGN_KEY: ${{ secrets.APP_IMAGE_SIGN_KEY }}
+          APPIMAGETOOL_SIGN_PASSPHRASE: ${{ secrets.APP_IMAGE_SIGN_PASSPHRASE }}
+
+      - name: Build Desktop App
+        if: matrix.settings.host == 'macos-latest' && matrix.settings.cli_only == false
+        uses: tauri-apps/tauri-action@v0.4.0
+        with:
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          projectPath: "./desktop"
+          args: "--target ${{ matrix.settings.target }}"
           includeUpdaterJson: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -185,10 +202,6 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          # AppImage Signing:
-          SIGN: ${{ secrets.APP_IMAGE_SIGN }}
-          SIGN_KEY: ${{ secrets.APP_IMAGE_SIGN_KEY }}
-          APPIMAGETOOL_SIGN_PASSPHRASE: ${{ secrets.APP_IMAGE_SIGN_PASSPHRASE }}
 
       - name: Build RPM
         if: matrix.settings.host == 'ubuntu-latest' && matrix.settings.cli_only == false

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -16,7 +16,8 @@
 To build the app on Linux, you will need the following dependencies:
 
 ```console
-sudo apt-get install libappindicator3-1 libgdk-pixbuf2.0-0 libbsd0 libxdmcp6 libwmf-0.2-7 libwmf-0.2-7-gtk libgtk-3-0 libwmf-dev libwebkit2gtk-4.0-37 librust-openssl-sys-dev
+sudo apt-get install libappindicator3-1 libgdk-pixbuf2.0-0 libbsd0 libxdmcp6 libwmf-0.2-7 libwmf-0.2-7-gtk libgtk-3-0 libwmf-dev libwebkit2gtk-4.0-37 librust-openssl-sys-dev librust-glib-sys-dev
+ sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev
 ```
 
 ### Additional Information

--- a/desktop/src-tauri/tauri-linux.conf.json
+++ b/desktop/src-tauri/tauri-linux.conf.json
@@ -1,0 +1,20 @@
+{
+  "tauri": {
+    "windows": [
+      {
+        "title": "DevPod",
+        "width": 1200,
+        "height": 800,
+        "minWidth": 1000,
+        "minHeight": 700,
+        "x": 0,
+        "y": 0,
+        "focus": false,
+        "titleBarStyle": "Overlay",
+        "fullscreen": false,
+        "resizable": true,
+        "hiddenTitle": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Right now tauri builds with `visible: false` are creating sparse problems with windows not appearing in some distributions.

For now we'll disable that on linux