### PR TITLE
fix hack/rebuild.sh to not required root to have go installed

### DIFF
--- a/hack/rebuild.sh
+++ b/hack/rebuild.sh
@@ -7,7 +7,7 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-s -w" -o test/devpod-c
 CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w" -o test/devpod-cli-darwin-arm64
 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o test/devpod-cli-darwin-amd64
 CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o test/devpod-cli-windows-amd64
-sudo go build -o /usr/local/bin/devpod
+go build -o test/devpod && sudo mv test/devpod /usr/local/bin/
 cp test/devpod-cli-linux-amd64 test/devpod-linux-amd64
 cp test/devpod-cli-linux-arm64 test/devpod-linux-arm64
 cp test/devpod-cli-linux-amd64 desktop/src-tauri/bin/devpod-cli-x86_64-unknown-linux-gnu


### PR DESCRIPTION
With the current rebuild.sh, root is required to have golang installed as ````sudo go build```` is done.
This PR allow the build to be done under the current user and then sudo is only required to move the build into destination folder