### PR TITLE
fix issue 292, where find container failed when using podman

### DIFF
--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -77,7 +77,7 @@ func (r *Runner) runSingleContainer(parsedConfig *config.SubstitutedConfig, work
 		//TODO: wait here a bit for correct startup?
 
 		// get container details
-		containerDetails, err = r.Driver.FindDevContainer(context.TODO(), labels)
+		containerDetails, err = r.Driver.FindDevContainer(context.TODO(), labels[0:1])
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixing issue #292:
Modifying FindDevContainer to only search by the ID and not ID+metadata.