### PR TITLE
Correctly specify how to find DevPod version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -24,7 +24,7 @@ My *`devcontainer.json`*:
 ```
 
 **Local Environment:**  
-- DevPod Version: [use `devpod --version`]
+- DevPod Version: [use `devpod version`]
 - Operating System: windows | linux | mac
 - ARCH of the OS: AMD64 | ARM64 | i386 
 


### PR DESCRIPTION
`version` is a command rather than a `--version` flag.