### PR TITLE
replace hard written docker with workspaceInfo.Agent.Docker.Path + allow env variables to be passed into docker command

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -239,7 +239,7 @@ func rerunAsRoot(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) (b
 	dockerRootRequired := false
 	if workspaceInfo == nil || workspaceInfo.Agent.Driver == "" || workspaceInfo.Agent.Driver == provider2.DockerDriver {
 		var err error
-		dockerRootRequired, err = dockerReachable(workspaceInfo.Agent.Docker.Path, workspaceInfo.Agent.Docker.Envs)
+		dockerRootRequired, err = dockerReachable(workspaceInfo.Agent.Docker.Path, workspaceInfo.Agent.Docker.Env)
 		if err != nil {
 			log.Debugf("Error trying to reach docker daemon: %v", err)
 			dockerRootRequired = true

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -18,6 +19,8 @@ import (
 
 type DockerHelper struct {
 	DockerCommand string
+	// allow command to have a custom environment
+	Environment []string
 }
 
 func (r *DockerHelper) GPUSupportEnabled() (bool, error) {
@@ -183,5 +186,9 @@ func (r *DockerHelper) FindContainer(labels []string) ([]string, error) {
 }
 
 func (r *DockerHelper) buildCmd(ctx context.Context, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, r.DockerCommand, args...)
+	cmd := exec.CommandContext(ctx, r.DockerCommand, args...)
+	if r.Environment != nil {
+		cmd.Env = append(os.Environ(), r.Environment...)
+	}
+	return cmd
 }

--- a/pkg/driver/docker/build.go
+++ b/pkg/driver/docker/build.go
@@ -305,7 +305,7 @@ func (d *dockerDriver) buildxBuild(ctx context.Context, writer io.Writer, platfo
 	args = append(args, options.Context)
 
 	// run command
-	d.Log.Debugf("Running docker command: docker %s", strings.Join(args, " "))
+	d.Log.Debugf("Running docker %s: docker %s", d.Docker.DockerCommand, strings.Join(args, " "))
 	err := d.Docker.Run(ctx, args, nil, writer, writer)
 	if err != nil {
 		return errors.Wrap(err, "build image")

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -41,7 +41,7 @@ func NewDockerDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger
 	}
 
 	log.Debugf("Using docker command '%s'", dockerCommand)
-	dockerHelper := &docker.DockerHelper{DockerCommand: dockerCommand, Environment: makeEnvironment(workspaceInfo.Agent.Docker.Envs)}
+	dockerHelper := &docker.DockerHelper{DockerCommand: dockerCommand, Environment: makeEnvironment(workspaceInfo.Agent.Docker.Env)}
 	return &dockerDriver{
 		Docker: dockerHelper,
 		Log:    log,

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -21,6 +21,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func makeEnvironment(env map[string]string) []string {
+	if env == nil {
+		return nil
+	}
+
+	var ret []string
+	for k, v := range env {
+		ret = append(ret, k+"="+v)
+	}
+
+	return ret
+}
+
 func NewDockerDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) driver.Driver {
 	dockerCommand := "docker"
 	if workspaceInfo.Agent.Docker.Path != "" {
@@ -28,7 +41,7 @@ func NewDockerDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger
 	}
 
 	log.Debugf("Using docker command '%s'", dockerCommand)
-	dockerHelper := &docker.DockerHelper{DockerCommand: dockerCommand}
+	dockerHelper := &docker.DockerHelper{DockerCommand: dockerCommand, Environment: makeEnvironment(workspaceInfo.Agent.Docker.Envs)}
 	return &dockerDriver{
 		Docker: dockerHelper,
 		Log:    log,
@@ -63,7 +76,7 @@ func (d *dockerDriver) PushDevContainer(ctx context.Context, image string) error
 	}
 
 	// run command
-	d.Log.Debugf("Running docker command: docker %s", strings.Join(args, " "))
+	d.Log.Debugf("Running docker command: %s %s", d.Docker.DockerCommand, strings.Join(args, " "))
 	err := d.Docker.Run(ctx, args, nil, writer, writer)
 	if err != nil {
 		return errors.Wrap(err, "push image")
@@ -211,7 +224,7 @@ func (d *dockerDriver) RunDevContainer(
 	args = append(args, cmd...)
 
 	// run the command
-	d.Log.Debugf("Running docker command: docker %s", strings.Join(args, " "))
+	d.Log.Debugf("Running docker command: %s %s", d.Docker.DockerCommand, strings.Join(args, " "))
 	writer := d.Log.Writer(logrus.InfoLevel, false)
 	defer writer.Close()
 

--- a/pkg/options/resolve.go
+++ b/pkg/options/resolve.go
@@ -186,7 +186,7 @@ func ResolveAgentConfig(devConfig *config.Config, provider *provider2.ProviderCo
 	agentConfig.Local = types.StrBool(resolveDefaultValue(string(agentConfig.Local), options))
 	agentConfig.Docker.Path = resolveDefaultValue(agentConfig.Docker.Path, options)
 	agentConfig.Docker.Install = types.StrBool(resolveDefaultValue(string(agentConfig.Docker.Install), options))
-	agentConfig.Docker.Envs = resolveDefaultValues(agentConfig.Docker.Envs, options)
+	agentConfig.Docker.Env = resolveDefaultValues(agentConfig.Docker.Env, options)
 	agentConfig.Kubernetes.Path = resolveDefaultValue(agentConfig.Kubernetes.Path, options)
 	agentConfig.Kubernetes.HelperImage = resolveDefaultValue(agentConfig.Kubernetes.HelperImage, options)
 	agentConfig.Kubernetes.Config = resolveDefaultValue(agentConfig.Kubernetes.Config, options)

--- a/pkg/options/resolve.go
+++ b/pkg/options/resolve.go
@@ -186,6 +186,7 @@ func ResolveAgentConfig(devConfig *config.Config, provider *provider2.ProviderCo
 	agentConfig.Local = types.StrBool(resolveDefaultValue(string(agentConfig.Local), options))
 	agentConfig.Docker.Path = resolveDefaultValue(agentConfig.Docker.Path, options)
 	agentConfig.Docker.Install = types.StrBool(resolveDefaultValue(string(agentConfig.Docker.Install), options))
+	agentConfig.Docker.Envs = resolveDefaultValues(agentConfig.Docker.Envs, options)
 	agentConfig.Kubernetes.Path = resolveDefaultValue(agentConfig.Kubernetes.Path, options)
 	agentConfig.Kubernetes.HelperImage = resolveDefaultValue(agentConfig.Kubernetes.HelperImage, options)
 	agentConfig.Kubernetes.Config = resolveDefaultValue(agentConfig.Kubernetes.Config, options)
@@ -484,6 +485,15 @@ func resolveDefaultValue(val string, resolvedOptions map[string]string) string {
 
 		return s
 	})
+}
+
+// replace all value in the map with the resolved default value
+func resolveDefaultValues(vals map[string]string, resolvedOptions map[string]string) map[string]string {
+	ret := make(map[string]string)
+	for k, v := range vals {
+		ret[k] = resolveDefaultValue(v, resolvedOptions)
+	}
+	return ret
 }
 
 func addDependencies(g *graph.Graph, options map[string]*provider2.ProviderOption) error {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -167,7 +167,7 @@ type ProviderDockerDriverConfig struct {
 	Install types.StrBool `json:"install,omitempty"`
 
 	// Environment variables to set when running docker commands
-	Envs map[string]string `json:"envs,omitempty"`
+	Env map[string]string `json:"envs,omitempty"`
 }
 
 type ProviderAgentConfigExec struct {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -165,6 +165,9 @@ type ProviderDockerDriverConfig struct {
 
 	// If false, DevPod will not try to install docker into the machine.
 	Install types.StrBool `json:"install,omitempty"`
+
+	// Environment variables to set when running docker commands
+	Envs map[string]string `json:"envs,omitempty"`
 }
 
 type ProviderAgentConfigExec struct {


### PR DESCRIPTION
1. in some places docker command is hard written such as [dockerReachable](https://github.com/loft-sh/devpod/blob/7ec3edaf696fac8169e84a61a6bc7cb51e91212a/pkg/agent/agent.go\#L324), it can cause problems since the command may not exists or not the one that should be called since we explicitely provide another one

2. in some cases it will be helpfull to pass some enviromnent variables to the command, such as DOCKER_HOST, etc... So for that i added a new envs mapping into the driver docker agent section:
```
  docker:
    path: /my/custom/command
    envs:
      DOCKER_HOST: "${API_BASE_URL}"
      ...
      KEY: VALUE
    install: false
```