### PR TITLE
fix: add sudo password check

### DIFF
--- a/pkg/inject/inject.sh
+++ b/pkg/inject/inject.sh
@@ -26,6 +26,9 @@ command_exists() {
   command -v "$@" >/dev/null 2>&1
 }
 
+sudo_password_required() {
+}
+
 is_arm() {
   case "$(uname -a)" in
   *arm* ) true;;
@@ -78,6 +81,12 @@ if {{ .ExistsCheck }}; then
   sh_c='sh -c'
   if [ "$user" != 'root' ]; then
     if command_exists sudo; then
+      # check if sudo requires a password
+      if echo $(sudo -n uptime 2>&1) | grep -q "a password is required"; then
+        >&2 echo Error: sudo requires a password and no password is available. Please ensure your user account is configured with NOPASSWD.
+        exit 1
+      fi
+
       sh_c='sudo -E sh -c'
     elif command_exists su; then
       sh_c='su -c'

--- a/pkg/inject/inject.sh
+++ b/pkg/inject/inject.sh
@@ -26,9 +26,6 @@ command_exists() {
   command -v "$@" >/dev/null 2>&1
 }
 
-sudo_password_required() {
-}
-
 is_arm() {
   case "$(uname -a)" in
   *arm* ) true;;


### PR DESCRIPTION
When connecting to an SSH provider with a user account that needs to enter a password when running `sudo`, the default behaviour is to fail silently and retry until timing out. Debug output (see below) makes the problem obvious, but it would still be better if the injection process failed early with a clear message.

Ideally, there would a way to flag up the need for a password to the desktop user and ask them to enter it, but I'm hoping this will do as a stop gap for now.

Open to guidance on how to handle this more gracefully.

```
[18:30:50] info Waiting for devpod agent to come up...
[18:30:50] debug Inject Error: bash: cannot set terminal process group (4333): Inappropriate ioctl for device
bash: no job control in this shell
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
sudo: a password is required
EOF
```