### PR TITLE
fix: update add provider from url example to use a working url

### DIFF
--- a/docs/pages/managing-providers/add-provider.mdx
+++ b/docs/pages/managing-providers/add-provider.mdx
@@ -87,7 +87,7 @@ devpod provider add ../devpod-provider-mock/provider.yaml
 You can also specify the URL to the `provider.yaml` file, for example:
 
 ```sh
-devpod provider add https://raw.githubusercontent.com/loft-sh/devpod-provider-ssh/main/hack/provider/provider.yaml
+devpod provider add https://github.com/loft-sh/devpod-provider-ssh/releases/download/v0.0.3/provider.yaml
 ```
 
 ## Set Provider Options


### PR DESCRIPTION
The SSH provider's YAML file is actually a template which is prepared for release by GitHub Actions. Targeting it with `devpod provider add` results in an error, users should target the GitHub release download instead.