### PR TITLE
fix: resolve openvscode process eating CPU when using docker

### DIFF
--- a/pkg/copy/copy.go
+++ b/pkg/copy/copy.go
@@ -37,6 +37,7 @@ func ChownR(path string, userName string) error {
 	}
 
 	uid, _ := strconv.Atoi(userID.Uid)
+	gid, _ := strconv.Atoi(userID.Gid)
 	return filepath.WalkDir(path, func(name string, dirEntry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -52,7 +53,7 @@ func ChownR(path string, userName string) error {
 		}
 
 		if err == nil {
-			err = os.Chown(name, uid, -1)
+			err = os.Chown(name, uid, gid)
 		}
 		return err
 	})

--- a/pkg/ide/openvscode/openvscode.go
+++ b/pkg/ide/openvscode/openvscode.go
@@ -36,7 +36,7 @@ var Options = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the open vscode binary",
-		Default:     "v1.76.2",
+		Default:     "v1.78.2",
 	},
 	OpenOption: {
 		Name:        OpenOption,
@@ -210,7 +210,7 @@ func (o *OpenVSCodeServer) installSettings() error {
 		return err
 	}
 
-	err = copy2.ChownR(settingsDir, o.userName)
+	err = copy2.ChownR(location, o.userName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When using Openvscode (Web Vscode) with Docker, a process keeps 1 core of the cpu binned to 100%.
This does not happen in Podman.

Turns out this is because of a permission problem, where the `.openvscode` directory had some inaccessible files/dirs for permissions.

This PR fixes this, and contextually upgrades openvscode to the latest release v1.78.2