### PR TITLE
fix panic : fatal agent error: panic: runtime error: index out of range [2]

### DIFF
--- a/pkg/dockerfile/parse.go
+++ b/pkg/dockerfile/parse.go
@@ -124,7 +124,7 @@ func (d *Dockerfile) findValue(buildArgs map[string]string, baseImageEnv map[str
 
 		// search args
 		if considerArg {
-			for i := len(stage.Args) - 1; i >= 0; i++ {
+			for i := len(stage.Args) - 1; i >= 0; i-- {
 				if stage.Args[i].Key != variable || stage.Args[i].Line >= untilLine {
 					continue
 				}

--- a/pkg/dockerfile/parse.go
+++ b/pkg/dockerfile/parse.go
@@ -138,7 +138,7 @@ func (d *Dockerfile) findValue(buildArgs map[string]string, baseImageEnv map[str
 		}
 
 		// search env
-		for i := len(stage.Envs) - 1; i >= 0; i++ {
+		for i := len(stage.Envs) - 1; i >= 0; i-- {
 			if stage.Envs[i].Key != variable || stage.Envs[i].Line >= untilLine {
 				continue
 			}


### PR DESCRIPTION
I just fall on this bug today with  fatal agent error: panic: runtime error: index out of range [2] with length 2 goroutine 1.

And after investigating found that [i is incremented when it should be decremented](https://github.com/loft-sh/devpod/blob/204d0decc41768ff5494c396462220c948d14995/pkg/dockerfile/parse.go#L141)  also [here](https://github.com/loft-sh/devpod/blob/204d0decc41768ff5494c396462220c948d14995/pkg/dockerfile/parse.go#L127)