### PR TITLE
fix: implement volume deletion when removing a devcontainer

### DIFF
--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -56,7 +56,20 @@ func (r *DockerHelper) FindDevContainer(labels []string) (*config.ContainerDetai
 }
 
 func (r *DockerHelper) DeleteVolume(ctx context.Context, volume string) error {
-	out, err := r.buildCmd(ctx, "volume", "rm", volume).CombinedOutput()
+	if volume == "" {
+		return nil
+	}
+
+	// If volume does not exist, just exit
+	out, err := r.buildCmd(ctx, "volume", "list", "-q", "--filter", "name="+volume).CombinedOutput()
+	if err != nil {
+		return nil
+	}
+	if len(out) == 0 {
+		return nil
+	}
+
+	out, err = r.buildCmd(ctx, "volume", "rm", volume).CombinedOutput()
 	if err != nil {
 		return perrors.Wrapf(err, "%s", string(out))
 	}

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -55,6 +55,15 @@ func (r *DockerHelper) FindDevContainer(labels []string) (*config.ContainerDetai
 	return nil, nil
 }
 
+func (r *DockerHelper) DeleteVolume(ctx context.Context, volume string) error {
+	out, err := r.buildCmd(ctx, "volume", "rm", volume).CombinedOutput()
+	if err != nil {
+		return perrors.Wrapf(err, "%s", string(out))
+	}
+
+	return nil
+}
+
 func (r *DockerHelper) Stop(ctx context.Context, id string) error {
 	out, err := r.buildCmd(ctx, "stop", id).CombinedOutput()
 	if err != nil {

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -101,7 +101,6 @@ func (d *dockerDriver) DeleteDevContainer(ctx context.Context, id string, delete
 		volume = container[0].Config.Labels["dev.containers.id"]
 	}
 
-
 	err := d.Docker.Remove(ctx, id)
 	if err != nil {
 		return err

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -98,6 +98,9 @@ func (d *dockerDriver) DeleteDevContainer(ctx context.Context, id string, delete
 		if err != nil {
 			return err
 		}
+		if len(container) == 0 {
+			return errors.Errorf("cannot find container")
+		}
 		volume = container[0].Config.Labels["dev.containers.id"]
 	}
 

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -90,9 +90,28 @@ func (d *dockerDriver) StartDevContainer(ctx context.Context, id string, labels 
 }
 
 func (d *dockerDriver) DeleteDevContainer(ctx context.Context, id string, deleteVolumes bool) error {
-	// TODO: implement deleteVolumes
+	var volume string
 
-	return d.Docker.Remove(ctx, id)
+	if deleteVolumes {
+		// inspect container deleteVolumes
+		container, err := d.Docker.InspectContainers([]string{id})
+		if err != nil {
+			return err
+		}
+		volume = container[0].Config.Labels["dev.containers.id"]
+	}
+
+
+	err := d.Docker.Remove(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if deleteVolumes {
+		return d.Docker.DeleteVolume(ctx, volume)
+	}
+
+	return nil
 }
 
 func (d *dockerDriver) StopDevContainer(ctx context.Context, id string) error {


### PR DESCRIPTION
Right now deleting a workspace will leave its docker volumes behing
This implements the volume deletion when removing a devcontainer