### PR TITLE
fix: agent panic when workspace is not in home

### DIFF
--- a/pkg/inject/inject.sh
+++ b/pkg/inject/inject.sh
@@ -53,7 +53,7 @@ download() {
   if is_arm; then
     DOWNLOAD_URL="{{ .DownloadArm }}"
   fi
-  
+
   while :; do
     cmd_status=""
     if command_exists curl; then
@@ -79,8 +79,7 @@ if {{ .ExistsCheck }}; then
 
   # Try to create the install dir, if we fail, we search for sudo
   # else let's continue without sudo, we don't need it.
-  $sh_c "mkdir -p $INSTALL_DIR"
-  if [ "$?" -ne 0 ]; then
+  if ! mkdir -p $INSTALL_DIR; then
     if command_exists sudo; then
       # check if sudo requires a password
       if ! sudo -nl >/dev/null 2>&1; then
@@ -100,7 +99,7 @@ if {{ .ExistsCheck }}; then
     $sh_c "mkdir -p $INSTALL_DIR"
   fi
 
-  
+
   if [ "$PREFER_DOWNLOAD" = "true" ]; then
     download || inject
   else


### PR DESCRIPTION
This PR has a couple of fixes:

- the inject.sh mkdir check is more solid now
- when using `agent workspace get-result` sometimes the file are not readable by the default user, because the agent is running as root and puts the workspace files in /root instead of /home/devpod

Fixes https://github.com/loft-sh/devpod-provider-aws/issues/7