### PR TITLE
feat: add provider command to list installable providers

### DIFF
--- a/cmd/provider/list-default-providers.go
+++ b/cmd/provider/list-default-providers.go
@@ -16,9 +16,6 @@ import (
 // ListAvailableCmd holds the list cmd flags
 type ListAvailableCmd struct {
 	flags.GlobalFlags
-
-	Output string
-	Used   bool
 }
 
 var httpClient = &http.Client{

--- a/cmd/provider/list-default-providers.go
+++ b/cmd/provider/list-default-providers.go
@@ -51,8 +51,8 @@ func getDevpodProviderList() error {
 	fmt.Println("List of available providers from loft:")
 	for _, v := range jsonResult {
 		if strings.Contains(v["name"].(string), "devpod-provider") {
-			name := strings.Split(v["name"].(string), "-")
-			fmt.Println("\t", name[len(name)-1])
+			name := strings.TrimPrefix(v["name"].(string), "devpod-provider-")
+			fmt.Println("\t", name)
 		}
 	}
 

--- a/cmd/provider/list-default-providers.go
+++ b/cmd/provider/list-default-providers.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/loft-sh/devpod/cmd/flags"
+	"github.com/spf13/cobra"
+)
+
+// ListAvailableCmd holds the list cmd flags
+type ListAvailableCmd struct {
+	flags.GlobalFlags
+
+	Output string
+	Used   bool
+}
+
+var httpClient = &http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	},
+}
+
+func getDevpodProviderList() error {
+	req, err := http.NewRequest("GET", "https://api.github.com/users/loft-sh/repos", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	result, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var jsonResult []map[string]interface{}
+	err = json.Unmarshal(result, &jsonResult)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("List of available providers from loft:")
+	for _, v := range jsonResult {
+		if strings.Contains(v["name"].(string), "devpod-provider") {
+			name := strings.Split(v["name"].(string), "-")
+			fmt.Println("\t", name[len(name)-1])
+		}
+	}
+
+	return nil
+}
+
+// NewListAvailableCmd creates a new command
+func NewListAvailableCmd(flags *flags.GlobalFlags) *cobra.Command {
+	cmd := &ListAvailableCmd{
+		GlobalFlags: *flags,
+	}
+	listAvailableCmd := &cobra.Command{
+		Use:   "list-available",
+		Short: "List providers available for installation",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return cmd.Run(context.Background())
+		},
+	}
+
+	return listAvailableCmd
+}
+
+// Run runs the command logic
+func (cmd *ListAvailableCmd) Run(ctx context.Context) error {
+	return getDevpodProviderList()
+}

--- a/cmd/provider/provider.go
+++ b/cmd/provider/provider.go
@@ -13,6 +13,7 @@ func NewProviderCmd(flags *flags.GlobalFlags) *cobra.Command {
 	}
 
 	providerCmd.AddCommand(NewListCmd(flags))
+	providerCmd.AddCommand(NewListAvailableCmd(flags))
 	providerCmd.AddCommand(NewUseCmd(flags))
 	providerCmd.AddCommand(NewOptionsCmd(flags))
 	providerCmd.AddCommand(NewDeleteCmd(flags))

--- a/docs/pages/managing-providers/add-provider.mdx
+++ b/docs/pages/managing-providers/add-provider.mdx
@@ -18,6 +18,12 @@ These providers can be installed with the DevPod CLI in the following form:
 devpod provider add docker
 ```
 
+You can get a list of available 1st party providers by using the command:
+
+```
+devpod provider list-available
+```
+
 ## Via DevPod Desktop Application
 
 Navigate to the 'Providers' view and click on the 'Add' button in the title.


### PR DESCRIPTION
This should ease the life of a CLI-only user.

It gets on par with what is already available on GUI, a list of our 1st party providers ready to install.

Resolves ENG-1326
