### PR TITLE
Avoid "Text file busy" during download/injection

### DIFF
--- a/pkg/inject/inject.sh
+++ b/pkg/inject/inject.sh
@@ -38,7 +38,8 @@ is_arm() {
 
 inject() {
   echo "ARM-$(is_arm && echo -n 'true' || echo -n 'false')"
-  $sh_c "cat > $INSTALL_PATH"
+  $sh_c "cat > $INSTALL_PATH.$$"
+  $sh_c "mv $INSTALL_PATH.$$ $INSTALL_PATH"
 
   if [ "$CHMOD_PATH" = "true" ]; then
     $sh_c "chmod +x $INSTALL_PATH"
@@ -57,10 +58,10 @@ download() {
   while :; do
     cmd_status=""
     if command_exists curl; then
-        $sh_c "curl -fsSL $DOWNLOAD_URL -o $INSTALL_PATH" && break
+        $sh_c "curl -fsSL $DOWNLOAD_URL -o $INSTALL_PATH.$$" && break
         cmd_status=$?
     elif command_exists wget; then
-        $sh_c "wget -q $DOWNLOAD_URL -O $INSTALL_PATH" && break
+        $sh_c "wget -q $DOWNLOAD_URL -O $INSTALL_PATH.$$" && break
         cmd_status=$?
     else
         echo "error: no download tool found, please install curl or wget"
@@ -71,6 +72,8 @@ download() {
     >&2 echo "Trying again in 10 seconds..."
     sleep 10
   done
+
+  $sh_c "mv $INSTALL_PATH.$$ $INSTALL_PATH"
 }
 
 if {{ .ExistsCheck }}; then


### PR DESCRIPTION
Don't download/inject to the same inode, in case it is already in use.

This PR takes the conservative approach of writing to a tempfile and then
renaming over the original in a second step.  This means a later (failed)
download/inject won't corrupt any existing file.

Fixes "Text file busy" error:

```
16:57:57 info Inject binary
16:57:57 info done exec
16:57:58 info Done injecting binary
16:57:58 info done inject
16:57:58 info done injecting
16:57:58 info Inject Error: sh: 1: cannot create /usr/local/bin/devpod: Text file busy
16:57:58 info write |1: file already closed
```