### PR TITLE
docs: add community providers section

### DIFF
--- a/docs/pages/managing-providers/add-provider.mdx
+++ b/docs/pages/managing-providers/add-provider.mdx
@@ -220,3 +220,17 @@ In **the CLI** you can set this option using:
 ```sh
 devpod provider use <provider-name>
 ```
+
+## Community Providers
+
+The community maintains providers for additional services.
+
+- [Cloudbit (cloudbit-ch/devpod-provider-cloudbit)](https://github.com/cloudbit-ch/devpod-provider-cloudbit)
+- [Flow (flowswiss/devpod-provider-flow)](https://github.com/flowswiss/devpod-provider-flow)
+- [Hetzner (mrsimonemms/devpod-provider-hetzner)](https://github.com/mrsimonemms/devpod-provider-hetzner)
+- [OVHcloud (alexandrevilain/devpod-provider-ovhcloud)](https://github.com/alexandrevilain/devpod-provider-ovhcloud)
+
+These providers can be installed with the DevPod CLI in the following form:
+```
+devpod provider add <user/repository>
+```


### PR DESCRIPTION
Added a section containing some community-supported providers. Aside from a [provider I did this weekend](https://github.com/mrsimonemms/devpod-provider-hetzner), the others are from a [message in Slack](https://loft-sh.slack.com/archives/C056ZDZPJ4W/p1686571333877349) and from a [tweet retweeted by @devpod](https://twitter.com/OVHcloud_Tech/status/1665635676799266820).

The idea is to provide a centralised list of providers for the benefit of the community, but without DevPod engineers having to increase what they support.