### PR TITLE
fix: properly check kubectl success on init. Force workspace folder deletion

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -112,7 +112,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context, devPodConfig *config.Config, args
 		GracePeriod: duration,
 	})
 	if err != nil {
-		return errors.Wrap(err, clientimplementation.DeleteWorkspaceFolder(client.Context(), client.Workspace(), log.Default).Error())
+		return err
 	}
 
 	log.Default.Donef("Successfully deleted workspace '%s'", client.Workspace())

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -112,10 +112,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context, devPodConfig *config.Config, args
 		GracePeriod: duration,
 	})
 	if err != nil {
-		err2 := clientimplementation.DeleteWorkspaceFolder(client.Context(), client.Workspace(), log.Default)
-		if err2 != nil {
-			return errors.Wrap(err2, err.Error())
-		}
+		return errors.Wrap(err, clientimplementation.DeleteWorkspaceFolder(client.Context(), client.Workspace(), log.Default).Error())
 	}
 
 	log.Default.Donef("Successfully deleted workspace '%s'", client.Workspace())

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -112,7 +112,10 @@ func (cmd *DeleteCmd) Run(ctx context.Context, devPodConfig *config.Config, args
 		GracePeriod: duration,
 	})
 	if err != nil {
-		return err
+		err2 := clientimplementation.DeleteWorkspaceFolder(client.Context(), client.Workspace(), log.Default)
+		if err2 != nil {
+			return errors.Wrap(err2, err.Error())
+		}
 	}
 
 	log.Default.Donef("Successfully deleted workspace '%s'", client.Workspace())

--- a/providers/kubernetes/provider.yaml
+++ b/providers/kubernetes/provider.yaml
@@ -1,5 +1,5 @@
 name: kubernetes
-version: v0.0.1
+version: v0.0.2
 icon: https://devpod.sh/assets/kubernetes.svg
 home: https://github.com/loft-sh/devpod
 description: |-
@@ -95,11 +95,11 @@ agent:
 exec:
   init: |-
     # Check if kubernetes is reachable
-    KUBERNETES_REACHABLE=$(KUBECONFIG=${KUBERNETES_CONFIG} ${KUBECTL_PATH} get pods --namespace=${KUBERNETES_NAMESPACE} --context=${KUBERNETES_CONTEXT} > /dev/null 2>&1 && echo -n "true" || echo -n "false")
-    if [ "KUBERNETES_REACHABLE" = "false" ]; then
+    KUBERNETES_REACHABLE=$(${KUBECTL_PATH} get pods --kubeconfig=${KUBERNETES_CONFIG} --namespace=${KUBERNETES_NAMESPACE} --context=${KUBERNETES_CONTEXT} > /dev/null 2>&1 && echo -n "true" || echo -n "false")
+    if [ "$KUBERNETES_REACHABLE" = "false" ]; then
       >&2 echo "Seems like kubernetes is not reachable on your system."
       >&2 echo "Please make sure kubectl is installed and working."
-      >&2 echo "You can verify if kubectl is working correctly via: KUBECONFIG=${KUBERNETES_CONFIG} ${KUBECTL_PATH} get pods --namespace=${KUBERNETES_NAMESPACE} --context=${KUBERNETES_CONTEXT}"
+      >&2 echo "You can verify if kubectl is working correctly via: ${KUBECTL_PATH} get pods --kubeconfig=${KUBERNETES_CONFIG} --namespace=${KUBERNETES_NAMESPACE} --context=${KUBERNETES_CONTEXT}"
       exit 1
     fi
 

--- a/providers/kubernetes/provider.yaml
+++ b/providers/kubernetes/provider.yaml
@@ -1,5 +1,5 @@
 name: kubernetes
-version: v0.0.2
+version: v0.0.1
 icon: https://devpod.sh/assets/kubernetes.svg
 home: https://github.com/loft-sh/devpod
 description: |-


### PR DESCRIPTION
Right now the k8s init wasn't working properly, allowing for invalid kubeconfig paths, and values
Contextually this would lead to `delete` to not actually delete the workspace dir, thus making the user stuck with the "wrong" config, not able to update it and requiring manual intervention.

Resolves ENG-1600