### PR TITLE
tests: add integration tests for SSH provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ devpod
 # Unit test targets
 main
 profile.out
+tags

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/onsi/gomega"
 
 	// Register tests
+	_ "github.com/loft-sh/devpod/e2e/tests/integration"
 	_ "github.com/loft-sh/devpod/e2e/tests/machine"
 	_ "github.com/loft-sh/devpod/e2e/tests/provider"
 	_ "github.com/loft-sh/devpod/e2e/tests/ssh"
 	_ "github.com/loft-sh/devpod/e2e/tests/up"
-	_ "github.com/loft-sh/devpod/e2e/tests/integration"
 )
 
 // TestRunE2ETests checks configuration parameters (specified through flags) and then runs

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/loft-sh/devpod/e2e/tests/provider"
 	_ "github.com/loft-sh/devpod/e2e/tests/ssh"
 	_ "github.com/loft-sh/devpod/e2e/tests/up"
+	_ "github.com/loft-sh/devpod/e2e/tests/integration"
 )
 
 // TestRunE2ETests checks configuration parameters (specified through flags) and then runs

--- a/e2e/tests/integration/framework.go
+++ b/e2e/tests/integration/framework.go
@@ -1,0 +1,8 @@
+package integration
+
+import "github.com/onsi/ginkgo/v2"
+
+// DevPodDescribe annotates the test with the label.
+func DevPodDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[integration] "+text, body)
+}

--- a/e2e/tests/integration/integration.go
+++ b/e2e/tests/integration/integration.go
@@ -11,7 +11,7 @@ import (
 
 var _ = ginkgo.Describe("[integration]: devpod provider ssh test suite", ginkgo.Ordered, func() {
 
-	ginkgo.FIt("should add provider to devpod", func() {
+	ginkgo.It("should add provider to devpod", func() {
 		// ensure we don't have the ssh provider present
 		cmd := exec.Command("bin/devpod-linux-amd64", "provider", "delete", "ssh")
 		err := cmd.Run()
@@ -24,14 +24,14 @@ var _ = ginkgo.Describe("[integration]: devpod provider ssh test suite", ginkgo.
 		framework.ExpectNoError(err)
 	})
 
-	ginkgo.FIt("should run devpod up", func() {
+	ginkgo.It("should run devpod up", func() {
 		// ensure we don't have the ssh provider present
 		cmd := exec.Command("bin/devpod-linux-amd64", "up", "--debug", "--ide=none", "tests/integration/testdata/")
 		err := cmd.Run()
 		framework.ExpectNoError(err)
 	})
 
-	ginkgo.FIt("should run commands to workspace via ssh", func() {
+	ginkgo.It("should run commands to workspace via ssh", func() {
 		// ensure we don't have the ssh provider present
 		cmd := exec.Command("ssh", "testdata.devpod", "echo", "test")
 		output, err := cmd.Output()
@@ -40,7 +40,7 @@ var _ = ginkgo.Describe("[integration]: devpod provider ssh test suite", ginkgo.
 		gomega.Expect(output).To(gomega.Equal([]byte("test\n")))
 	})
 
-	ginkgo.FIt("should cleanup devpod workspace", func() {
+	ginkgo.It("should cleanup devpod workspace", func() {
 		// ensure we don't have the ssh provider present
 		cmd := exec.Command("bin/devpod-linux-amd64", "delete", "--debug", "--force", "testdata")
 		err := cmd.Run()

--- a/e2e/tests/integration/integration.go
+++ b/e2e/tests/integration/integration.go
@@ -1,0 +1,49 @@
+package integration
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/loft-sh/devpod/e2e/framework"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("[integration]: devpod provider ssh test suite", ginkgo.Ordered, func() {
+
+	ginkgo.FIt("should add provider to devpod", func() {
+		// ensure we don't have the ssh provider present
+		cmd := exec.Command("bin/devpod-linux-amd64", "provider", "delete", "ssh")
+		err := cmd.Run()
+		if err != nil {
+			fmt.Println("warning: " + err.Error())
+		}
+
+		cmd = exec.Command("bin/devpod-linux-amd64", "provider", "add", "ssh", "-o", "HOST=localhost")
+		err = cmd.Run()
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.FIt("should run devpod up", func() {
+		// ensure we don't have the ssh provider present
+		cmd := exec.Command("bin/devpod-linux-amd64", "up", "--debug", "--ide=none", "tests/integration/testdata/")
+		err := cmd.Run()
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.FIt("should run commands to workspace via ssh", func() {
+		// ensure we don't have the ssh provider present
+		cmd := exec.Command("ssh", "testdata.devpod", "echo", "test")
+		output, err := cmd.Output()
+		framework.ExpectNoError(err)
+
+		gomega.Expect(output).To(gomega.Equal([]byte("test\n")))
+	})
+
+	ginkgo.FIt("should cleanup devpod workspace", func() {
+		// ensure we don't have the ssh provider present
+		cmd := exec.Command("bin/devpod-linux-amd64", "delete", "--debug", "--force", "testdata")
+		err := cmd.Run()
+		framework.ExpectNoError(err)
+	})
+})

--- a/e2e/tests/integration/testdata/.devcontainer.json
+++ b/e2e/tests/integration/testdata/.devcontainer.json
@@ -1,0 +1,4 @@
+{
+	"name": "Go",
+	"image": "mcr.microsoft.com/devcontainers/go:0-1.19-bullseye"
+}


### PR DESCRIPTION
This will add a new tests that runs the integration with the ssh-provider
This goes in hand with https://github.com/loft-sh/devpod-provider-ssh/pull/6 in order to test
compatibility both on devpod changes and provider changes.