### PR TITLE
fix: make setopt command not fail

### DIFF
--- a/pkg/inject/inject.sh
+++ b/pkg/inject/inject.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 set -e
 
-if [ "$SHELL" != "${SHELL%"/zsh"*}" ]; then
-  setopt SH_WORD_SPLIT || :
-fi
+# Compatibility fix for zsh shells
+setopt SH_WORD_SPLIT 2>/dev/null || :
 
 INSTALL_DIR="{{ .InstallDir }}"
 INSTALL_FILENAME="{{ .InstallFilename }}"

--- a/pkg/inject/inject.sh
+++ b/pkg/inject/inject.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "$SHELL" != "${SHELL%"/zsh"*}" ]; then
-  setopt SH_WORD_SPLIT
+  setopt SH_WORD_SPLIT || :
 fi
 
 INSTALL_DIR="{{ .InstallDir }}"


### PR DESCRIPTION
This will

Fix #464 
Resolve ENG-1676

Setop is needed on ZSH if it's directly called as such, so let's allow it to fail in case 