### PR TITLE
Support workspaces from branches with slash in the name.

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -11,7 +11,7 @@ import (
 	"github.com/loft-sh/devpod/pkg/command"
 )
 
-var branchRegEx = regexp.MustCompile(`[^a-zA-Z0-9\.\-]+`)
+var branchRegEx = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@]+)@([a-zA-Z0-9\./-]+)$`)
 
 func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "git", args...)
@@ -28,17 +28,9 @@ func NormalizeRepository(str string) (string, string) {
 
 	// resolve branch
 	branch := ""
-	index := strings.LastIndex(str, "@")
-	if index != -1 {
-		branch = str[index+1:]
-		repo := str[:index]
-
-		// is not a valid tag / branch name?
-		if branchRegEx.MatchString(branch) {
-			branch = ""
-		} else {
-			str = repo
-		}
+	if match := branchRegEx.FindStringSubmatch(str); match != nil {
+		str = match[1]
+		branch = match[2]
 	}
 
 	return str, branch

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,0 +1,65 @@
+package git
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	"gotest.tools/assert/cmp"
+)
+
+type testCaseNormalizeRepository struct {
+	in             string
+	expectedRepo   string
+	expectedBranch string
+}
+
+func TestNormalizeRepository(t *testing.T) {
+	testCases := []testCaseNormalizeRepository{
+		{
+			in:             "ssh://github.com/loft-sh/devpod.git",
+			expectedRepo:   "ssh://github.com/loft-sh/devpod.git",
+			expectedBranch: "",
+		},
+		{
+			in:             "git@github.com/loft-sh/devpod-without-branch.git",
+			expectedRepo:   "git@github.com/loft-sh/devpod-without-branch.git",
+			expectedBranch: "",
+		},
+		{
+			in:             "https://github.com/loft-sh/devpod.git",
+			expectedRepo:   "https://github.com/loft-sh/devpod.git",
+			expectedBranch: "",
+		},
+		{
+			in:             "github.com/loft-sh/devpod.git",
+			expectedRepo:   "https://github.com/loft-sh/devpod.git",
+			expectedBranch: "",
+		},
+		{
+			in:             "github.com/loft-sh/devpod.git@test-branch",
+			expectedRepo:   "https://github.com/loft-sh/devpod.git",
+			expectedBranch: "test-branch",
+		},
+		{
+			in:             "git@github.com/loft-sh/devpod-with-branch.git@test-branch",
+			expectedRepo:   "git@github.com/loft-sh/devpod-with-branch.git",
+			expectedBranch: "test-branch",
+		},
+		{
+			in:             "github.com/loft-sh/devpod-without-protocol-with-slash.git@user/branch",
+			expectedRepo:   "https://github.com/loft-sh/devpod-without-protocol-with-slash.git",
+			expectedBranch: "user/branch",
+		},
+		{
+			in:             "git@github.com/loft-sh/devpod-with-slash.git@user/branch",
+			expectedRepo:   "git@github.com/loft-sh/devpod-with-slash.git",
+			expectedBranch: "user/branch",
+		},
+	}
+
+	for _, testCase := range testCases {
+		outRepo, outBranch := NormalizeRepository(testCase.in)
+		assert.Check(t, cmp.Equal(testCase.expectedRepo, outRepo))
+		assert.Check(t, cmp.Equal(testCase.expectedBranch, outBranch))
+	}
+}


### PR DESCRIPTION
DevPod supports already creating workspaces from non-default branch by providing repository URL in the form of
`repository.host.abc/user/repo.git@branch`

With this change it accepts branches that contain slash in the name as this is common to name branch like `username/some-description`