### PR TITLE
Increment PhpStorm version to 2023.1.3

### DIFF
--- a/pkg/ide/jetbrains/phpstorm.go
+++ b/pkg/ide/jetbrains/phpstorm.go
@@ -13,7 +13,7 @@ var PhpStormOptions = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the binary",
-		Default:     "2023.1.1",
+		Default:     "2023.1.3",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,


### PR DESCRIPTION
The latest PhpStorm version is now 23.1.3. This updates the default version installed to that.