### PR TITLE
fix(#163): handle objects in the devcontainer lifecyle hooks

### DIFF
--- a/examples/object-lifecycle-hooks/.devcontainer.json
+++ b/examples/object-lifecycle-hooks/.devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "Object-Lifecycle",
+  "image": "mcr.microsoft.com/vscode/devcontainers/go:1",
+  "postStartCommand": {
+    "cobra-install": "go install github.com/spf13/cobra-cli@latest",
+    "golangci-lint": "go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest",
+    "errcheck": "go install github.com/kisielk/errcheck@latest"
+  }
+}

--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -68,7 +68,7 @@ type DevContainerConfigBase struct {
 	RemoteUser string `json:"remoteUser,omitempty"`
 
 	// A command to run locally before anything else. This command is run before "onCreateCommand". If this is a single string, it will be run in a shell. If this is an array of strings, it will be run as a single command without shell.
-	InitializeCommand types.StrArray `json:"initializeCommand,omitempty"`
+	InitializeCommand types.LifecycleHook `json:"initializeCommand,omitempty"`
 
 	// Action to take when the user disconnects from the container in their editor. The default is to stop the container.
 	ShutdownAction string `json:"shutdownAction,omitempty"`
@@ -103,24 +103,24 @@ type DevContainerConfigBase struct {
 
 type DevContainerActions struct {
 	// A command to run when creating the container. This command is run after "initializeCommand" and before "updateContentCommand". If this is a single string, it will be run in a shell. If this is an array of strings, it will be run as a single command without shell.
-	OnCreateCommand types.StrArray `json:"onCreateCommand,omitempty"`
+	OnCreateCommand types.LifecycleHook `json:"onCreateCommand,omitempty"`
 
 	// A command to run when creating the container and rerun when the workspace content was updated while creating the container.
 	// This command is run after "onCreateCommand" and before "postCreateCommand". If this is a single string, it will be run in a shell.
 	// If this is an array of strings, it will be run as a single command without shell.
-	UpdateContentCommand types.StrArray `json:"updateContentCommand,omitempty"`
+	UpdateContentCommand types.LifecycleHook `json:"updateContentCommand,omitempty"`
 
 	// A command to run after creating the container. This command is run after "updateContentCommand" and before "postStartCommand".
 	// If this is a single string, it will be run in a shell. If this is an array of strings, it will be run as a single command without shell.
-	PostCreateCommand types.StrArray `json:"postCreateCommand,omitempty"`
+	PostCreateCommand types.LifecycleHook `json:"postCreateCommand,omitempty"`
 
 	// A command to run after starting the container. This command is run after "postCreateCommand" and before "postAttachCommand".
 	// If this is a single string, it will be run in a shell. If this is an array of strings, it will be run as a single command without shell.
-	PostStartCommand types.StrArray `json:"postStartCommand,omitempty"`
+	PostStartCommand types.LifecycleHook `json:"postStartCommand,omitempty"`
 
 	// A command to run when attaching to the container. This command is run after "postStartCommand".
 	// If this is a single string, it will be run in a shell. If this is an array of strings, it will be run as a single command without shell.
-	PostAttachCommand types.StrArray `json:"postAttachCommand,omitempty"`
+	PostAttachCommand types.LifecycleHook `json:"postAttachCommand,omitempty"`
 
 	// Tool-specific configuration. Each tool should use a JSON object subproperty with a unique name to group its customizations.
 	Customizations map[string]interface{} `json:"customizations,omitempty"`
@@ -131,24 +131,24 @@ type UpdatedConfigProperties struct {
 	Entrypoints []string `json:"entrypoints,omitempty"`
 
 	// A command to run when creating the container. This command is run after "initializeCommand" and before "updateContentCommand". If this is a single string, it will be run in a shell. If this is an array of strings, it will be run as a single command without shell.
-	OnCreateCommands []types.StrArray `json:"onCreateCommand,omitempty"`
+	OnCreateCommands []types.LifecycleHook `json:"onCreateCommand,omitempty"`
 
 	// A command to run when creating the container and rerun when the workspace content was updated while creating the container.
 	// This command is run after "onCreateCommand" and before "postCreateCommand". If this is a single string, it will be run in a shell.
 	// If this is an array of strings, it will be run as a single command without shell.
-	UpdateContentCommands []types.StrArray `json:"updateContentCommand,omitempty"`
+	UpdateContentCommands []types.LifecycleHook `json:"updateContentCommand,omitempty"`
 
 	// A command to run after creating the container. This command is run after "updateContentCommand" and before "postStartCommand".
 	// If this is a single string, it will be run in a shell. If this is an array of strings, it will be run as a single command without shell.
-	PostCreateCommands []types.StrArray `json:"postCreateCommand,omitempty"`
+	PostCreateCommands []types.LifecycleHook `json:"postCreateCommand,omitempty"`
 
 	// A command to run after starting the container. This command is run after "postCreateCommand" and before "postAttachCommand".
 	// If this is a single string, it will be run in a shell. If this is an array of strings, it will be run as a single command without shell.
-	PostStartCommands []types.StrArray `json:"postStartCommand,omitempty"`
+	PostStartCommands []types.LifecycleHook `json:"postStartCommand,omitempty"`
 
 	// A command to run when attaching to the container. This command is run after "postStartCommand".
 	// If this is a single string, it will be run in a shell. If this is an array of strings, it will be run as a single command without shell.
-	PostAttachCommands []types.StrArray `json:"postAttachCommand,omitempty"`
+	PostAttachCommands []types.LifecycleHook `json:"postAttachCommand,omitempty"`
 
 	// Tool-specific configuration. Each tool should use a JSON object subproperty with a unique name to group its customizations.
 	Customizations map[string][]interface{} `json:"customizations,omitempty"`

--- a/pkg/devcontainer/config/merge.go
+++ b/pkg/devcontainer/config/merge.go
@@ -38,11 +38,11 @@ func MergeConfiguration(config *DevContainerConfig, imageMetadataEntries []*Imag
 	mergedConfig.SecurityOpt = unique(unionOrNil(reversed, func(entry *ImageMetadata) []string { return entry.SecurityOpt }))
 	mergedConfig.Entrypoints = collectOrNil(reversed, func(entry *ImageMetadata) string { return entry.Entrypoint })
 	mergedConfig.Mounts = mergeMounts(reversed)
-	mergedConfig.OnCreateCommands = collectOrNilArr(reversed, func(entry *ImageMetadata) types.StrArray { return entry.OnCreateCommand })
-	mergedConfig.UpdateContentCommands = collectOrNilArr(reversed, func(entry *ImageMetadata) types.StrArray { return entry.UpdateContentCommand })
-	mergedConfig.PostCreateCommands = collectOrNilArr(reversed, func(entry *ImageMetadata) types.StrArray { return entry.PostCreateCommand })
-	mergedConfig.PostStartCommands = collectOrNilArr(reversed, func(entry *ImageMetadata) types.StrArray { return entry.PostStartCommand })
-	mergedConfig.PostAttachCommands = collectOrNilArr(reversed, func(entry *ImageMetadata) types.StrArray { return entry.PostAttachCommand })
+	mergedConfig.OnCreateCommands = mergeLifestyleHooks(reversed, func(entry *ImageMetadata) types.LifecycleHook { return entry.OnCreateCommand })
+	mergedConfig.UpdateContentCommands = mergeLifestyleHooks(reversed, func(entry *ImageMetadata) types.LifecycleHook { return entry.UpdateContentCommand })
+	mergedConfig.PostCreateCommands = mergeLifestyleHooks(reversed, func(entry *ImageMetadata) types.LifecycleHook { return entry.PostCreateCommand })
+	mergedConfig.PostStartCommands = mergeLifestyleHooks(reversed, func(entry *ImageMetadata) types.LifecycleHook { return entry.PostStartCommand })
+	mergedConfig.PostAttachCommands = mergeLifestyleHooks(reversed, func(entry *ImageMetadata) types.LifecycleHook { return entry.PostAttachCommand })
 	mergedConfig.WaitFor = firstString(reversed, func(entry *ImageMetadata) string { return entry.WaitFor })
 	mergedConfig.RemoteUser = firstString(reversed, func(entry *ImageMetadata) string { return entry.RemoteUser })
 	mergedConfig.ContainerUser = firstString(reversed, func(entry *ImageMetadata) string { return entry.ContainerUser })
@@ -142,15 +142,14 @@ func mergeMounts(entries []*ImageMetadata) []*Mount {
 	return ReverseSlice(ret)
 }
 
-func collectOrNilArr(entries []*ImageMetadata, m func(entry *ImageMetadata) types.StrArray) []types.StrArray {
-	var out []types.StrArray
+func mergeLifestyleHooks(entries []*ImageMetadata, m func(entry *ImageMetadata) types.LifecycleHook) []types.LifecycleHook {
+	var out []types.LifecycleHook
 	for _, entry := range entries {
 		val := m(entry)
 		if len(val) > 0 {
 			out = append(out, m(entry))
 		}
 	}
-
 	return out
 }
 

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -172,26 +172,28 @@ func runInitializeCommand(workspaceFolder string, config *config.DevContainerCon
 		return nil
 	}
 
-	// should run in shell?
-	var args []string
-	if len(config.InitializeCommand) == 1 {
-		args = []string{"sh", "-c", config.InitializeCommand[0]}
-	} else {
-		args = config.InitializeCommand
-	}
+	for _, cmd := range config.InitializeCommand {
+		// should run in shell?
+		var args []string
+		if len(cmd) == 1 {
+			args = []string{"sh", "-c", cmd[0]}
+		} else {
+			args = cmd
+		}
 
-	// run the command
-	log.Infof("Running initializeCommand from devcontainer.json: '%s'", strings.Join(args, " "))
-	writer := log.Writer(logrus.InfoLevel, false)
-	defer writer.Close()
+		// run the command
+		log.Infof("Running initializeCommand from devcontainer.json: '%s'", strings.Join(args, " "))
+		writer := log.Writer(logrus.InfoLevel, false)
+		defer writer.Close()
 
-	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Stdout = writer
-	cmd.Stderr = writer
-	cmd.Dir = workspaceFolder
-	err := cmd.Run()
-	if err != nil {
-		return err
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Stdout = writer
+		cmd.Stderr = writer
+		cmd.Dir = workspaceFolder
+		err := cmd.Run()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,84 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/loft-sh/devpod/pkg/types"
+	"gotest.tools/assert"
+)
+
+func TestLifecycleHookUnmarshalJSON(t *testing.T) {
+	type input struct {
+		Input types.LifecycleHook `json:"input,omitempty"`
+	}
+
+	testCases := []struct {
+		Name   string
+		Input  string
+		Expect input
+	}{
+		{
+			Name:  "string",
+			Input: `{"input": "some-string"}`,
+			Expect: input{
+				Input: types.LifecycleHook{
+					"": []string{"some-string"},
+				},
+			},
+		},
+		{
+			Name:  "array of strings",
+			Input: `{"input": ["string1", "string2"]}`,
+			Expect: input{
+				Input: types.LifecycleHook{
+					"": []string{
+						"string1",
+						"string2",
+					},
+				},
+			},
+		},
+		{
+			Name:  "object of strings",
+			Input: `{"input": {"key1": "value1", "key2": "value2"}}`,
+			Expect: input{
+				Input: types.LifecycleHook{
+					"key1": []string{
+						"value1",
+					},
+					"key2": []string{
+						"value2",
+					},
+				},
+			},
+		},
+		{
+			Name:  "object of array of strings",
+			Input: `{"input": {"key1": ["value1","value2"], "key2": ["value3","value4"]}}`,
+			Expect: input{
+				Input: types.LifecycleHook{
+					"key1": []string{
+						"value1",
+						"value2",
+					},
+					"key2": []string{
+						"value3",
+						"value4",
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			var data input
+
+			err := json.Unmarshal([]byte(testCase.Input), &data)
+			assert.NilError(t, err, testCase.Name)
+
+			assert.DeepEqual(t, testCase.Expect, data)
+		})
+	}
+}


### PR DESCRIPTION
Following on from #380, this is a second attempt at solving #163 thanks to @pascalbreuninger's previous review.

Fixes #163 

This converts objects to an array of strings using a parallel Bash command. This does assume that `bash` is present on the devcontainers, which is probably a safe bet but I guess we could switch to `sh` if necessary.