### PR TITLE
fix: do not error out too soon when searching for docker-compose

### DIFF
--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -62,8 +61,6 @@ func NewComposeHelper(dockerComposeCLI string, dockerHelper *docker.DockerHelper
 			Args:    []string{},
 			Docker:  dockerHelper,
 		}, nil
-	} else if !os.IsNotExist(err) {
-		return nil, err
 	}
 
 	out, err := exec.Command(dockerCLI, "compose", "version", "--short").Output()


### PR DESCRIPTION
Fix #379 
Resolves ENG-1526

This solves the issue where the docker compose helper only searches for `docker-compose` while ignoring the (working) `docker compose` command