### PR TITLE
Fix/appimage cli path

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -17,7 +17,7 @@ To build the app on Linux, you will need the following dependencies:
 
 ```console
 sudo apt-get install libappindicator3-1 libgdk-pixbuf2.0-0 libbsd0 libxdmcp6 libwmf-0.2-7 libwmf-0.2-7-gtk libgtk-3-0 libwmf-dev libwebkit2gtk-4.0-37 librust-openssl-sys-dev librust-glib-sys-dev
- sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev
+ sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev file build-essential
 ```
 
 ### Additional Information


### PR DESCRIPTION
Fix #400 
Resolved ENG-1581

With this check, we detect if we're in an appimage or a tmps, and copy the CLI to path, instead of symlinking
