### PR TITLE
fix: escape function after successful clone

### DIFF
--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -212,6 +212,7 @@ func prepareWorkspace(ctx context.Context, workspaceInfo *provider2.AgentWorkspa
 			log.Errorf("Cloning failed: %v. Trying cloning on local machine and uploading folder", err)
 			return RemoteCloneAndDownload(ctx, workspaceInfo.ContentFolder, client, log)
 		}
+		return nil
 	} else if workspaceInfo.Workspace.Source.LocalFolder != "" {
 		log.Debugf("Download Local Folder")
 		return DownloadLocalFolder(ctx, workspaceInfo.ContentFolder, client, log)


### PR DESCRIPTION
Introduced in https://github.com/loft-sh/devpod/commit/350fac9f6ff85a825559ecbe809ef3e3ae8245f6 was a logic error where if `CloneRepository` succeeds without an error, the function is not exited and is caught by the catch-all 
```
return fmt.Errorf("either workspace repository, image or local-folder is required")
```

This PR updates the function so that if there's no error returned from `CloneRepository`, the function exits.