### PR TITLE
Fix lifecycle dependency failures

### DIFF
--- a/e2e/tests/up/testdata/docker-features-lifecycle-hooks/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-features-lifecycle-hooks/.devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "name": "Test Git",
+    "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu",
+    "features": {
+      "ghcr.io/devcontainers/features/git:1": {}
+    },
+    "postStartCommand": "git version"
+}

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -413,6 +413,25 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 				err = f.DevPodUp(ctx, tempDir, "--debug")
 				framework.ExpectNoError(err)
 			}, ginkgo.SpecTimeout(60*time.Second))
+
+			ginkgo.Context("should start a new workspace with features", func() {
+				ginkgo.It("ensure dependencies installed via features are accessible in lifecycle hooks", func(ctx context.Context) {
+					tempDir, err := framework.CopyToTempDir("tests/up/testdata/docker-features-lifecycle-hooks")
+					framework.ExpectNoError(err)
+					ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+					f := framework.NewDefaultFramework(initialDir + "/bin")
+					_ = f.DevPodProviderAdd(ctx, "docker")
+					err = f.DevPodProviderUse(context.Background(), "docker")
+					framework.ExpectNoError(err)
+
+					ginkgo.DeferCleanup(f.DevPodWorkspaceDelete, context.Background(), tempDir)
+
+					// Wait for devpod workspace to come online (deadline: 30s)
+					err = f.DevPodUp(ctx, tempDir, "--debug")
+					framework.ExpectNoError(err)
+				}, ginkgo.SpecTimeout(60*time.Second))
+			})
 		})
 
 		ginkgo.Context("with docker-compose", func() {

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -87,6 +87,14 @@ func (r *Runner) runSingleContainer(ctx context.Context, parsedConfig *config.Su
 		}
 	}
 
+	// set remoteenv
+	if mergedConfig.RemoteEnv == nil {
+		mergedConfig.RemoteEnv = make(map[string]string)
+	}
+	if _, ok := mergedConfig.RemoteEnv["PATH"]; !ok {
+		mergedConfig.RemoteEnv["PATH"] = "${containerEnv:PATH}"
+	}
+
 	// substitute config with container env
 	newMergedConfig := &config.MergedDevContainerConfig{}
 	err = config.SubstituteContainerEnv(config.ListToObject(containerDetails.Config.Env), mergedConfig, newMergedConfig)


### PR DESCRIPTION
With this PR we are building the remoteEnv from the containerEnv which is gathered from the container. This helps any lifecycle hooks to run with the proper environment set.

Fixes #522 
Fixes ENG-1742