### PR TITLE
Ensure correct uid and gid for remoteUser based on the workspace owner

### DIFF
--- a/e2e/tests/up/testdata/docker-dockerfile-customuser/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-dockerfile-customuser/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+}

--- a/e2e/tests/up/testdata/docker-dockerfile-customuser/Dockerfile
+++ b/e2e/tests/up/testdata/docker-dockerfile-customuser/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.19.11-bullseye
+
+ARG UNAME=vscode
+ARG UID=1007
+ARG GID=1007
+
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
+
+USER $UNAME
+
+CMD /bin/bash

--- a/e2e/tests/up/testdata/docker-root/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-root/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "Go",
+	"image": "mcr.microsoft.com/devcontainers/go:0-1.19-bullseye",
+	"remoteUser": "root"
+}

--- a/pkg/devcontainer/setup/userinfo_supported.go
+++ b/pkg/devcontainer/setup/userinfo_supported.go
@@ -1,0 +1,25 @@
+//go:build !windows
+// +build !windows
+
+package setup
+
+import (
+	"fmt"
+	"io/fs"
+	"strconv"
+	"syscall"
+)
+
+func GetUserInfo(info fs.FileInfo) (string, string, error) {
+	var UID, GID string
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return UID, GID, fmt.Errorf("file read error")
+	}
+
+	UID = strconv.Itoa(int(stat.Uid))
+	GID = strconv.Itoa(int(stat.Gid))
+
+	return UID, GID, nil
+}

--- a/pkg/devcontainer/setup/userinfo_unsupported.go
+++ b/pkg/devcontainer/setup/userinfo_unsupported.go
@@ -1,0 +1,13 @@
+//go:build windows
+// +build windows
+
+package setup
+
+import (
+	"fmt"
+	"io/fs"
+)
+
+func GetUserInfo(info fs.FileInfo) (string, string, error) {
+	return "", "", fmt.Errorf("userinfo is currently not supported on windows")
+}


### PR DESCRIPTION
With this PR, we update the UID of the remote user to match that of the host user. This is done to overcome the classic file permissions issue.
This change is applied only if the host OS is linux or the driver is kubernetes and the host UID is different than the remote user's UID.

P.S. In case of certain IDE's like openvscode, you may need to recreate the devcontainer for the changes to take effect. This can be done using the below command.
```
devpod up <URL-or-local-path> --recreate
```


Fixes #498 
Fixes ENG-1720
Fixes #601 
Fixes ENG-1854