### PR TITLE
Fix pod manifest template

### DIFF
--- a/pkg/driver/kubernetes/run.go
+++ b/pkg/driver/kubernetes/run.go
@@ -286,7 +286,6 @@ func getContainers(pod *corev1.Pod, imageName, entrypoint string, args []string,
 	// merge with existing container if it exists
 	var existingDevPodContainer *corev1.Container
 	retContainers := []corev1.Container{}
-	retContainers = append(retContainers, devPodContainer)
 	if pod != nil {
 		for i, container := range pod.Spec.Containers {
 			if container.Name == DevContainerName {
@@ -300,6 +299,7 @@ func getContainers(pod *corev1.Pod, imageName, entrypoint string, args []string,
 		devPodContainer.Env = append(existingDevPodContainer.Env, devPodContainer.Env...)
 		devPodContainer.VolumeMounts = append(existingDevPodContainer.VolumeMounts, devPodContainer.VolumeMounts...)
 	}
+	retContainers = append(retContainers, devPodContainer)
 
 	return retContainers
 }


### PR DESCRIPTION
Hello,

I just tested the latest release, and the pod manifest template feature was not working as expected.
the env vars and volume mounts were not kept from the template.

This patch fix it 