### PR TITLE
Add option to use kubectl exec to copy file

### DIFF
--- a/pkg/driver/kubernetes/run.go
+++ b/pkg/driver/kubernetes/run.go
@@ -244,12 +244,23 @@ func (k *kubernetesDriver) runContainer(
 				cmd.Stdin = r
 				cmd.Stdout = buf
 				cmd.Stderr = buf
-				tarCmd.Start()
-				cmd.Start()
-				tarCmd.Wait()
+				err = tarCmd.Start()
+				if err != nil {
+					return fmt.Errorf("Error running command '%s'", tarCmd)
+				}
+				err = cmd.Start()
+				if err != nil {
+					return fmt.Errorf("Error running command '%s'", cmd)
+				}
+				err = tarCmd.Wait()
+				if err != nil {
+					return fmt.Errorf("Error waiting for command '%s'", tarCmd)
+				}
 				w.Close()
-				cmd.Wait()
-
+				err = cmd.Wait()
+				if err != nil {
+					return fmt.Errorf("Error waiting for command '%s'", cmd)
+				}
 			}
 			if err != nil {
 				return errors.Wrap(err, "copy to devcontainer")

--- a/pkg/options/resolve.go
+++ b/pkg/options/resolve.go
@@ -207,6 +207,7 @@ func ResolveAgentConfig(devConfig *config.Config, provider *provider2.ProviderCo
 	agentConfig.Docker.Install = types.StrBool(resolver.ResolveDefaultValue(string(agentConfig.Docker.Install), options))
 	agentConfig.Docker.Env = resolver.ResolveDefaultValues(agentConfig.Docker.Env, options)
 	agentConfig.Kubernetes.Path = resolver.ResolveDefaultValue(agentConfig.Kubernetes.Path, options)
+	agentConfig.Kubernetes.UseKubectlCp = types.StrBool(resolver.ResolveDefaultValue(string(agentConfig.Kubernetes.UseKubectlCp), options))
 	agentConfig.Kubernetes.HelperImage = resolver.ResolveDefaultValue(agentConfig.Kubernetes.HelperImage, options)
 	agentConfig.Kubernetes.Config = resolver.ResolveDefaultValue(agentConfig.Kubernetes.Config, options)
 	agentConfig.Kubernetes.Context = resolver.ResolveDefaultValue(agentConfig.Kubernetes.Context, options)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -129,6 +129,9 @@ type ProviderKubernetesDriverConfig struct {
 	// Path where to find the kubectl binary, defaults to 'kubectl'
 	Path string `json:"path,omitempty"`
 
+	// Use kubectl cp (or  tar ... | kubectl exec ) to send file to the ppd
+	UseKubectlCp types.StrBool `json:"useKubectlCp,omitempty"`
+
 	// Namespace is the Kubernetes namespace to use
 	Namespace string `json:"namespace,omitempty"`
 

--- a/providers/kubernetes/provider.yaml
+++ b/providers/kubernetes/provider.yaml
@@ -26,6 +26,7 @@ optionGroups:
       - SERVICE_ACCOUNT
       - CREATE_NAMESPACE
       - KUBECTL_PATH
+      - USE_KUBECTL_CP
       - INACTIVITY_TIMEOUT
       - STORAGE_CLASS
       - PVC_ACCESS_MODE
@@ -83,6 +84,11 @@ options:
     description: The path where to find the kubectl binary.
     default: kubectl
     global: true
+  USE_KUBECTL_CP:
+    description: Use 'kubectl cp' to send files to the pod.
+    default: "true"
+    type: boolean
+    global: true
   INACTIVITY_TIMEOUT:
     description: "If defined, will automatically stop the pod after the inactivity period. Examples: 10m, 1h"
   STORAGE_CLASS:
@@ -115,6 +121,7 @@ agent:
   driver: kubernetes
   kubernetes:
     path: ${KUBECTL_PATH}
+    useKubectlCp: ${USE_KUBECTL_CP}
     namespace: ${KUBERNETES_NAMESPACE}
     context: ${KUBERNETES_CONTEXT}
     config: ${KUBERNETES_CONFIG}


### PR DESCRIPTION
Based on https://kubernetes.io/docs/reference/kubectl/cheatsheet/#copying-files-and-directories-to-and-from-containers, I thought it was a good idea to have an other way to send files

![image](https://github.com/loft-sh/devpod/assets/47721/a4c4089e-c366-4762-8b77-b8d62472d021)
