### PR TITLE
feat: add dotfiles repo support

### DIFF
--- a/cmd/agent/workspace/install_dotfiles.go
+++ b/cmd/agent/workspace/install_dotfiles.go
@@ -1,0 +1,131 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/loft-sh/devpod/cmd/flags"
+	"github.com/loft-sh/devpod/pkg/git"
+	"github.com/loft-sh/log"
+	"github.com/spf13/cobra"
+)
+
+// InstallDotfilesCmd holds the installDotfiles cmd flags
+type InstallDotfilesCmd struct {
+	*flags.GlobalFlags
+
+	Repository    string
+	InstallScript string
+}
+
+// NewInstallDotfilesCmd creates a new command
+func NewInstallDotfilesCmd(flags *flags.GlobalFlags) *cobra.Command {
+	cmd := &InstallDotfilesCmd{
+		GlobalFlags: flags,
+	}
+	installDotfilesCmd := &cobra.Command{
+		Use:   "install-dotfiles",
+		Short: "installs input dotfiles in the container",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return cmd.Run(context.Background())
+		},
+	}
+	installDotfilesCmd.Flags().StringVar(&cmd.Repository, "repository", "", "The dotfiles repository")
+	installDotfilesCmd.Flags().StringVar(&cmd.InstallScript, "install-script", "", "The dotfiles install command to execute")
+	return installDotfilesCmd
+}
+
+// Run runs the command logic
+func (cmd *InstallDotfilesCmd) Run(ctx context.Context) error {
+	logger := log.Default.ErrorStreamOnly()
+
+	_, err := os.Stat("dotfiles")
+	if err == nil {
+		logger.Info("dotfiles already set up, skipping")
+
+		return nil
+	}
+
+	cloneArgs := []string{"clone", cmd.Repository, "dotfiles"}
+
+	logger.Infof("Cloning dotfiles %s", cmd.Repository)
+
+	err = git.CommandContext(ctx, cloneArgs...).Run()
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Entering dotfiles directory")
+
+	err = os.Chdir("dotfiles")
+	if err != nil {
+		return err
+	}
+
+	if cmd.InstallScript != "" {
+		logger.Infof("Executing install script %s", cmd.InstallScript)
+
+		return exec.Command("./" + cmd.InstallScript).Run()
+	}
+
+	logger.Debugf("Install script not specified, trying known locations")
+
+	return setupDotfiles(0, logger)
+}
+
+var scriptLocations = []string{
+	"./install.sh",
+	"./install",
+	"./bootstrap.sh",
+	"./bootstrap",
+	"./script/bootstrap",
+	"./setup.sh",
+	"./setup",
+	"./setup/setup",
+}
+
+func setupDotfiles(index int, logger log.Logger) error {
+	if index > len(scriptLocations)-1 {
+		logger.Debug("Finished script locations, trying to link the files")
+
+		files, err := os.ReadDir(".")
+		if err != nil {
+			return err
+		}
+
+		pwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		// link dotfiles in directory to home
+		for _, file := range files {
+			if strings.HasPrefix(file.Name(), ".") && !file.IsDir() {
+				logger.Debugf("linking %s in home", file.Name())
+
+				err = os.Symlink(filepath.Join(pwd, file.Name()), filepath.Join(os.Getenv("HOME"), file.Name()))
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	}
+
+	logger.Debugf("Trying executing %s", scriptLocations[index])
+
+	err := exec.Command(scriptLocations[index]).Run()
+	if err != nil {
+		logger.Debugf("Execution of %s was unsuccessful: %v", scriptLocations[index], err)
+		logger.Debug("Trying next location")
+
+		return setupDotfiles(index+1, logger)
+	}
+
+	return nil
+}

--- a/cmd/agent/workspace/workspace.go
+++ b/cmd/agent/workspace/workspace.go
@@ -20,5 +20,6 @@ func NewWorkspaceCmd(flags *flags.GlobalFlags) *cobra.Command {
 	workspaceCmd.AddCommand(NewUpdateConfigCmd(flags))
 	workspaceCmd.AddCommand(NewBuildCmd(flags))
 	workspaceCmd.AddCommand(NewLogsDaemonCmd(flags))
+	workspaceCmd.AddCommand(NewInstallDotfilesCmd(flags))
 	return workspaceCmd
 }

--- a/docs/pages/developing-in-workspaces/dotfiles-in-a-workspace.mdx
+++ b/docs/pages/developing-in-workspaces/dotfiles-in-a-workspace.mdx
@@ -1,0 +1,62 @@
+---
+title: Dotfiles in a Workspace
+sidebar_label: Dotfiles in a Workspace
+---
+
+## Personalizing a Workspace
+
+You can personalize your workspace environment by using a `dotfiles` repository.
+
+Dotfiles are plain text configuration files on Unix like systems (e.g. MacOS, Linux, BSD).  
+Dotfiles store settings of almost every application, service and tool running on your system.  
+It is common practice to track dotfiles with a version control system such as Git
+to keep track of changes and synchronize dotfiles across various hosts. 
+
+You can use the `--dotfiles` flag when creating a workspace, so that DevPod will
+automatically clone and install your dotfiles in the workspace.
+
+If you only specify the dotfiles repo, DevPod will clone your selected dotfiles
+repository into the workspace, and will look into one of these locations to find
+a script to setup the environment.
+
+- install.sh
+- install
+- bootstrap.sh
+- bootstrap
+- script/bootstrap
+- setup.sh
+- setup
+- script/setup
+
+If none of the previous location are found, DevPod will just link every hidden file (files starting with `.`)
+in the `$HOME` directory of the container.
+
+If is possible to specify **custom install script locations** for your special setup. 
+If a custom install script is specified, DevPod will directly run that one instead.
+
+### Via DevPod CLI
+
+Run the following command to a workspace with a dotfiles repo:
+
+```
+devpod up https://github.com/example/repo --dotfiles https://github.com/my-user/my-dotfiles-repo
+```
+
+Specifying a custom install script:
+
+```
+devpod up https://github.com/example/repo --dotfiles https://github.com/my-user/my-dotfiles-repo --dotfiles-script custom/location/install.sh
+```
+
+#### For all Workspaces
+
+You can setup these options on a **context wide scope** so that you won't have to specify
+dotfiles ad dotfiles-script for each single workspace:
+
+Example with a real repository:
+
+```
+devpod context set-options -o DOTFILES_URL=https://github.com/89luca89/dotfiles -o DOTFILES_SCRIPT=bin/.local/bin/dotfiles
+```
+
+All new Workspaces will be created with that dotfile repository and install script.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -75,6 +75,10 @@ module.exports = {
         },
         {
           type: "doc",
+          id: "developing-in-workspaces/dotfiles-in-a-workspace",
+        },
+        {
+          type: "doc",
           id: "developing-in-workspaces/credentials",
         },
         {

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -114,6 +114,7 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
 
+		_ = f.DevPodProviderDelete(ctx, "kubernetes")
 		err = f.DevPodProviderAdd(ctx, "kubernetes", "-o", "KUBERNETES_NAMESPACE=devpod")
 		framework.ExpectNoError(err)
 		ginkgo.DeferCleanup(func() {
@@ -225,7 +226,6 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			out, err := f.DevPodList(ctx)
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(out, initialList)
-
 		}, ginkgo.SpecTimeout(60*time.Second))
 		ginkgo.It("ensure workspace cleanup when not a git or folder", func(ctx context.Context) {
 			f := framework.NewDefaultFramework(initialDir + "/bin")
@@ -267,7 +267,6 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 
 				err = exec.Command(initialDir+"/bin/podman-rootful", "ps").Run()
 				framework.ExpectNoError(err)
-
 			}, ginkgo.SpecTimeout(60*time.Second))
 
 			ginkgo.It("should start a new workspace with existing image", func(ctx context.Context) {
@@ -477,7 +476,6 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 /home/vscode/.file3
 `
 				framework.ExpectEqual(out, expectedOutput, "should match")
-
 			}, ginkgo.SpecTimeout(60*time.Second))
 			ginkgo.It("should start a new workspace with dotfiles - install script", func(ctx context.Context) {
 				tempDir, err := framework.CopyToTempDir("tests/up/testdata/docker")
@@ -504,7 +502,6 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 				expectedOutput := "/tmp/worked\n"
 
 				framework.ExpectEqual(out, expectedOutput, "should match")
-
 			}, ginkgo.SpecTimeout(60*time.Second))
 		})
 
@@ -1388,5 +1385,4 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			})
 		})
 	})
-
 })

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -7,6 +7,8 @@ const (
 	ContextOptionExitAfterTimeout           = "EXIT_AFTER_TIMEOUT"
 	ContextOptionTelemetry                  = "TELEMETRY"
 	ContextOptionAgentURL                   = "AGENT_URL"
+	ContextOptionDotfilesURL                = "DOTFILES_URL"
+	ContextOptionDotfilesScript             = "DOTFILES_SCRIPT"
 )
 
 var ContextOptions = []ContextOption{
@@ -43,5 +45,13 @@ var ContextOptions = []ContextOption{
 	{
 		Name:        ContextOptionAgentURL,
 		Description: "Specifies the agent url to use for DevPod",
+	},
+	{
+		Name:        ContextOptionDotfilesURL,
+		Description: "Specifies the dotfiles repo url to use for DevPod",
+	},
+	{
+		Name:        ContextOptionDotfilesScript,
+		Description: "Specifies the script to run after cloning dotfiles repo to install them",
 	},
 }


### PR DESCRIPTION
This PR adds support for cloning a dotfiles repo during workspace creation
Such repo will be cloned in the main container's user's HOME, and the following script locations will be checked to find install scripts:

- install.sh
- install
- bootstrap.sh
- bootstrap
- script/bootstrap
- setup.sh
- setup
- setup/setup

If no script is found, it will simply link all dotfiles in the root of the repo into $HOME.

Additional script locations can be specified in order to support custom install scripts, for example, for my dotfiles repo https://github.com/89luca89/dotfiles I can specify `bin/.local/bin/dotfiles` that will perform the installation.

Repo URL and script locations can be specified either via command flags in the `up` command:

```sh
devpod up my-project --dotfiles https://github.com/89luca89/dotfiles
devpod up my-project --dotfiles https://github.com/89luca89/dotfiles --dotfiles-script "bin/.local/bin/dotfiles"
``` 

Or they can be specified at context level:

```sh
devpod context set-options -o DOTFILES_URL=https://github.com/89luca89/dotfiles -o DOTFILES_SCRIPT=bin/.local/bin/dotfiles
```

In case both context and flags are specified, the flags of the command take precedence

Fix #455 
Resolves ENG-1666