### PR TITLE
Rebuild on changes to files in build context

### DIFF
--- a/e2e/tests/up/testdata/docker-dockerfile-buildcontext/.devcontainer/devcontainer.json
+++ b/e2e/tests/up/testdata/docker-dockerfile-buildcontext/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "name": "Test",
+    "build": {
+        "dockerfile": "../Dockerfile"
+    }
+}

--- a/e2e/tests/up/testdata/docker-dockerfile-buildcontext/.dockerignore
+++ b/e2e/tests/up/testdata/docker-dockerfile-buildcontext/.dockerignore
@@ -1,0 +1,1 @@
+scripts/install.sh

--- a/e2e/tests/up/testdata/docker-dockerfile-buildcontext/Dockerfile
+++ b/e2e/tests/up/testdata/docker-dockerfile-buildcontext/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu
+
+COPY scripts /scripts
+
+CMD bash

--- a/e2e/tests/up/testdata/docker-dockerfile-buildcontext/scripts/alias.sh
+++ b/e2e/tests/up/testdata/docker-dockerfile-buildcontext/scripts/alias.sh
@@ -1,0 +1,1 @@
+alias hello='echo Hello $USER'

--- a/e2e/tests/up/testdata/docker-dockerfile-buildcontext/scripts/install.sh
+++ b/e2e/tests/up/testdata/docker-dockerfile-buildcontext/scripts/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+apt update -y
+apt install curl

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -509,6 +509,112 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 
 				framework.ExpectEqual(out, expectedOutput, "should match")
 			}, ginkgo.SpecTimeout(60*time.Second))
+			ginkgo.Context("should start a workspace from a Dockerfile build", func() {
+				ginkgo.It("should rebuild image in case of changes in files in build context", func(ctx context.Context) {
+					tempDir, err := framework.CopyToTempDir("tests/up/testdata/docker-dockerfile-buildcontext")
+					framework.ExpectNoError(err)
+					ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+					f := framework.NewDefaultFramework(initialDir + "/bin")
+
+					_ = f.DevPodProviderDelete(ctx, "docker")
+					err = f.DevPodProviderAdd(ctx, "docker")
+					framework.ExpectNoError(err)
+					err = f.DevPodProviderUse(context.Background(), "docker")
+					framework.ExpectNoError(err)
+
+					ginkgo.DeferCleanup(f.DevPodWorkspaceDelete, context.Background(), tempDir)
+
+					// Wait for devpod workspace to come online (deadline: 30s)
+					err = f.DevPodUp(ctx, tempDir)
+					framework.ExpectNoError(err)
+
+					workspace, err := f.FindWorkspace(ctx, tempDir)
+					framework.ExpectNoError(err)
+
+					container, err := dockerHelper.FindDevContainer(ctx, []string{
+						fmt.Sprintf("%s=%s", config.DockerIDLabel, workspace.UID),
+					})
+					framework.ExpectNoError(err)
+
+					image1 := container.Config.Image
+
+					scriptFile, err := os.OpenFile(tempDir+"/scripts/alias.sh",
+						os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+					framework.ExpectNoError(err)
+
+					defer scriptFile.Close()
+
+					ginkgo.By("Changing a file within the context")
+					_, err = scriptFile.Write([]byte("alias yr='date +%Y'"))
+					framework.ExpectNoError(err)
+
+					ginkgo.By("Starting DevPod again with --recreate")
+					err = f.DevPodUp(ctx, tempDir, "--debug", "--recreate")
+					framework.ExpectNoError(err)
+
+					container, err = dockerHelper.FindDevContainer(ctx, []string{
+						fmt.Sprintf("%s=%s", config.DockerIDLabel, workspace.UID),
+					})
+					framework.ExpectNoError(err)
+
+					image2 := container.Config.Image
+
+					gomega.Expect(image2).ShouldNot(gomega.Equal(image1), "images should be different")
+				}, ginkgo.SpecTimeout(60*time.Second))
+				ginkgo.It("should not rebuild image for changes in files mentioned in .dockerignore", func(ctx context.Context) {
+					tempDir, err := framework.CopyToTempDir("tests/up/testdata/docker-dockerfile-buildcontext")
+					framework.ExpectNoError(err)
+					ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+					f := framework.NewDefaultFramework(initialDir + "/bin")
+
+					_ = f.DevPodProviderDelete(ctx, "docker")
+					err = f.DevPodProviderAdd(ctx, "docker")
+					framework.ExpectNoError(err)
+					err = f.DevPodProviderUse(context.Background(), "docker")
+					framework.ExpectNoError(err)
+
+					ginkgo.DeferCleanup(f.DevPodWorkspaceDelete, context.Background(), tempDir)
+
+					// Wait for devpod workspace to come online (deadline: 30s)
+					err = f.DevPodUp(ctx, tempDir)
+					framework.ExpectNoError(err)
+
+					workspace, err := f.FindWorkspace(ctx, tempDir)
+					framework.ExpectNoError(err)
+
+					container, err := dockerHelper.FindDevContainer(ctx, []string{
+						fmt.Sprintf("%s=%s", config.DockerIDLabel, workspace.UID),
+					})
+					framework.ExpectNoError(err)
+
+					image1 := container.Config.Image
+
+					scriptFile, err := os.OpenFile(tempDir+"/scripts/install.sh",
+						os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+					framework.ExpectNoError(err)
+
+					defer scriptFile.Close()
+
+					ginkgo.By("Changing a file within context")
+					_, err = scriptFile.Write([]byte("apt install python"))
+					framework.ExpectNoError(err)
+
+					ginkgo.By("Starting DevPod again with --recreate")
+					err = f.DevPodUp(ctx, tempDir, "--debug", "--recreate")
+					framework.ExpectNoError(err)
+
+					container, err = dockerHelper.FindDevContainer(ctx, []string{
+						fmt.Sprintf("%s=%s", config.DockerIDLabel, workspace.UID),
+					})
+					framework.ExpectNoError(err)
+
+					image2 := container.Config.Image
+
+					gomega.Expect(image2).Should(gomega.Equal(image1), "image should be same")
+				}, ginkgo.SpecTimeout(60*time.Second))
+			})
 		})
 
 		ginkgo.Context("with docker-compose", func() {

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/moby/patternmatcher v0.5.0 // indirect
+	github.com/moby/patternmatcher v0.5.0
 	github.com/moby/sys/signal v0.7.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/pkg/devcontainer/config/prebuild.go
+++ b/pkg/devcontainer/config/prebuild.go
@@ -2,13 +2,20 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
+
+	util "github.com/loft-sh/devpod/pkg/util/hash"
+	"github.com/moby/buildkit/frontend/dockerfile/dockerignore"
+	"github.com/moby/patternmatcher"
+	"github.com/pkg/errors"
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/hash"
 )
 
-func CalculatePrebuildHash(originalConfig *DevContainerConfig, platform, architecture, dockerfileContent string, log log.Logger) (string, error) {
+func CalculatePrebuildHash(originalConfig *DevContainerConfig, platform, architecture, contextPath, dockerfilePath, dockerfileContent string, log log.Logger) (string, error) {
 	parsedConfig := CloneDevContainerConfig(originalConfig)
 
 	if platform != "" {
@@ -43,6 +50,66 @@ func CalculatePrebuildHash(originalConfig *DevContainerConfig, platform, archite
 		return "", err
 	}
 
-	log.Debugf("Prebuild hash from: %s %s %s", architecture, string(configStr), dockerfileContent)
-	return "devpod-" + hash.String(architecture + string(configStr) + dockerfileContent)[:32], nil
+	excludes, err := readDockerignore(contextPath, dockerfilePath)
+	if err != nil {
+		return "", errors.Errorf("Error reading .dockerignore: %v", err)
+	}
+
+	// get hash of the context directory
+	contextHash, err := util.DirectoryHash(contextPath, excludes, false)
+	if err != nil {
+		return "", err
+	}
+
+	log.Debugf("Prebuild hash from: %s %s %s\n%s", architecture, string(configStr), dockerfileContent, contextHash)
+	return "devpod-" + hash.String(architecture + string(configStr) + dockerfileContent + contextHash)[:32], nil
+}
+
+// readDockerignore reads the .dockerignore file in the context directory and
+// returns the list of paths to exclude.
+func readDockerignore(contextDir string, dockerfile string) ([]string, error) {
+	var (
+		f        *os.File
+		err      error
+		excludes = []string{}
+	)
+
+	dockerignorefilepath := dockerfile + ".dockerignore"
+	if filepath.IsAbs(dockerignorefilepath) {
+		f, err = os.Open(dockerignorefilepath)
+	} else {
+		f, err = os.Open(filepath.Join(contextDir, dockerignorefilepath))
+	}
+	if os.IsNotExist(err) {
+		dockerignorefilepath = ".dockerignore"
+		f, err = os.Open(filepath.Join(contextDir, dockerignorefilepath))
+		if os.IsNotExist(err) {
+			return ensureDockerIgnoreAndDockerFile(excludes, dockerfile, dockerignorefilepath), nil
+		} else if err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	}
+
+	defer f.Close()
+
+	excludes, err = dockerignore.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	return ensureDockerIgnoreAndDockerFile(excludes, dockerfile, dockerignorefilepath), nil
+}
+
+func ensureDockerIgnoreAndDockerFile(excludes []string, dockerfile, dockerignorefilepath string) []string {
+	_, dockerignorefile := filepath.Split(dockerignorefilepath)
+	if keep, _ := patternmatcher.MatchesOrParentMatches(dockerignorefile, excludes); keep {
+		excludes = append(excludes, "!"+dockerignorefile)
+	}
+
+	if keep, _ := patternmatcher.MatchesOrParentMatches(dockerfile, excludes); keep {
+		excludes = append(excludes, "!"+dockerfile)
+	}
+
+	return excludes
 }

--- a/pkg/driver/docker/build.go
+++ b/pkg/driver/docker/build.go
@@ -35,7 +35,7 @@ func (d *dockerDriver) BuildDevContainer(
 	localWorkspaceFolder string,
 	options config.BuildOptions,
 ) (*config.BuildInfo, error) {
-	prebuildHash, err := config.CalculatePrebuildHash(parsedConfig.Config, options.Platform, runtime.GOARCH, dockerfileContent, d.Log)
+	prebuildHash, err := config.CalculatePrebuildHash(parsedConfig.Config, options.Platform, runtime.GOARCH, GetContextPath(parsedConfig.Config), dockerfilePath, dockerfileContent, d.Log)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func CreateBuildOptions(
 	if pushRepository != "" {
 		buildOptions.Images = append(buildOptions.Images, pushRepository+":"+prebuildHash)
 	}
-	buildOptions.Context = getContextPath(parsedConfig.Config)
+	buildOptions.Context = GetContextPath(parsedConfig.Config)
 
 	// add build arg
 	if buildOptions.BuildArgs == nil {
@@ -317,7 +317,7 @@ func (d *dockerDriver) buildxBuild(ctx context.Context, writer io.Writer, platfo
 	return nil
 }
 
-func getContextPath(parsedConfig *config.DevContainerConfig) string {
+func GetContextPath(parsedConfig *config.DevContainerConfig) string {
 	context := ""
 	dockerfilePath := ""
 	if parsedConfig.Dockerfile != "" {

--- a/pkg/driver/kubernetes/build.go
+++ b/pkg/driver/kubernetes/build.go
@@ -58,7 +58,7 @@ func (k *kubernetesDriver) BuildDevContainer(
 		return nil, err
 	}
 
-	prebuildHash, err := config.CalculatePrebuildHash(parsedConfig.Config, options.Platform, arch, dockerfileContent, k.Log)
+	prebuildHash, err := config.CalculatePrebuildHash(parsedConfig.Config, options.Platform, arch, docker.GetContextPath(parsedConfig.Config), dockerfilePath, dockerfileContent, k.Log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/hash/hash.go
+++ b/pkg/util/hash/hash.go
@@ -1,0 +1,204 @@
+package hash
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker/pkg/longpath"
+	"github.com/moby/patternmatcher"
+	"github.com/pkg/errors"
+)
+
+var (
+	maxFilesToRead             = 5000
+	errFileReadOverLimit error = errors.New("read files over limit")
+)
+
+func DirectoryHash(srcPath string, excludePatterns []string, fast bool) (string, error) {
+	srcPath, err := filepath.Abs(srcPath)
+	if err != nil {
+		return "", err
+	}
+
+	hash := sha256.New()
+
+	// Stat dir / file
+	fileInfo, err := os.Stat(srcPath)
+	if err != nil {
+		return "", err
+	}
+
+	// Hash file
+	if !fileInfo.IsDir() {
+		size := strconv.FormatInt(fileInfo.Size(), 10)
+		mTime := strconv.FormatInt(fileInfo.ModTime().UnixNano(), 10)
+		_, _ = io.WriteString(hash, srcPath+";"+size+";"+mTime)
+
+		return fmt.Sprintf("%x", hash.Sum(nil)), nil
+	}
+
+	// Fix the source path to work with long path names. This is a no-op
+	// on platforms other than Windows.
+	if runtime.GOOS == "windows" {
+		srcPath = longpath.AddPrefix(srcPath)
+	}
+
+	pm, err := patternmatcher.New(excludePatterns)
+	if err != nil {
+		return "", err
+	}
+
+	// In general we log errors here but ignore them because
+	// during e.g. a diff operation the container can continue
+	// mutating the filesystem and we can see transient errors
+	// from this
+
+	stat, err := os.Lstat(srcPath)
+	if err != nil {
+		return "", err
+	}
+
+	if !stat.IsDir() {
+		return "", errors.Errorf("Path %s is not a directory", srcPath)
+	}
+
+	include := "."
+	seen := make(map[string]bool)
+	filesRead := 0
+
+	walkRoot := filepath.Join(srcPath, include)
+	err = filepath.Walk(walkRoot, func(filePath string, f os.FileInfo, err error) error {
+		if err != nil {
+			return errors.Errorf("Hash: Can't stat file %s to hash: %s", srcPath, err)
+		}
+
+		if filesRead >= maxFilesToRead {
+			return errFileReadOverLimit
+		}
+
+		relFilePath, err := filepath.Rel(srcPath, filePath)
+		if err != nil {
+			// Error getting relative path OR we are looking
+			// at the source directory path. Skip in both situations.
+			return err
+		}
+
+		skip := false
+
+		// If "include" is an exact match for the current file
+		// then even if there's an "excludePatterns" pattern that
+		// matches it, don't skip it. IOW, assume an explicit 'include'
+		// is asking for that file no matter what - which is true
+		// for some files, like .dockerignore and Dockerfile (sometimes)
+		if relFilePath != "." {
+			skip, err = pm.MatchesOrParentMatches(relFilePath)
+			if err != nil {
+				return errors.Errorf("Error matching %s: %v", relFilePath, err)
+			}
+		}
+
+		if skip {
+			// If we want to skip this file and its a directory
+			// then we should first check to see if there's an
+			// excludes pattern (e.g. !dir/file) that starts with this
+			// dir. If so then we can't skip this dir.
+
+			// Its not a dir then so we can just return/skip.
+			if !f.IsDir() {
+				return nil
+			}
+
+			// No exceptions (!...) in patterns so just skip dir
+			if !pm.Exclusions() {
+				return filepath.SkipDir
+			}
+
+			dirSlash := relFilePath + string(filepath.Separator)
+
+			for _, pat := range pm.Patterns() {
+				if !pat.Exclusion() {
+					continue
+				}
+				if strings.HasPrefix(pat.String()+string(filepath.Separator), dirSlash) {
+					// found a match - so can't skip this dir
+					return nil
+				}
+			}
+
+			// No matching exclusion dir so just skip dir
+			return filepath.SkipDir
+		}
+
+		if seen[relFilePath] {
+			return nil
+		}
+		seen[relFilePath] = true
+		filesRead += 1
+		if f.IsDir() {
+			// Path is enough
+			_, _ = io.WriteString(hash, filePath)
+		} else {
+			if fast {
+				_, _ = io.WriteString(hash, filePath+";"+strconv.FormatInt(f.Size(), 10)+";"+strconv.FormatInt(f.ModTime().Unix(), 10))
+			} else {
+				// Check file change
+				checksum, err := hashFileCRC32(filePath, 0xedb88320)
+				if err != nil {
+					return nil
+				}
+
+				_, _ = io.WriteString(hash, filePath+";"+checksum)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil && !errors.Is(err, errFileReadOverLimit) {
+		return "", errors.Errorf("Error hashing %s: %v", srcPath, err)
+	}
+
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+func hashFileCRC32(filePath string, polynomial uint32) (string, error) {
+	//Initialize an empty return string now in case an error has to be returned
+	var returnCRC32String string
+
+	//Open the fhe file located at the given path and check for errors
+	file, err := os.Open(filePath)
+	if err != nil {
+		return returnCRC32String, err
+	}
+
+	//Tell the program to close the file when the function returns
+	defer file.Close()
+
+	//Create the table with the given polynomial
+	tablePolynomial := crc32.MakeTable(polynomial)
+
+	//Open a new hash interface to write the file to
+	hash := crc32.New(tablePolynomial)
+
+	//Copy the file in the interface
+	if _, err := io.Copy(hash, file); err != nil {
+		return returnCRC32String, err
+	}
+
+	//Generate the hash
+	hashInBytes := hash.Sum(nil)[:]
+
+	//Encode the hash to a string
+	returnCRC32String = hex.EncodeToString(hashInBytes)
+
+	//Return the output
+	return returnCRC32String, nil
+}

--- a/vendor/github.com/docker/docker/pkg/longpath/longpath.go
+++ b/vendor/github.com/docker/docker/pkg/longpath/longpath.go
@@ -1,0 +1,26 @@
+// longpath introduces some constants and helper functions for handling long paths
+// in Windows, which are expected to be prepended with `\\?\` and followed by either
+// a drive letter, a UNC server\share, or a volume identifier.
+
+package longpath // import "github.com/docker/docker/pkg/longpath"
+
+import (
+	"strings"
+)
+
+// Prefix is the longpath prefix for Windows file paths.
+const Prefix = `\\?\`
+
+// AddPrefix will add the Windows long path prefix to the path provided if
+// it does not already have it.
+func AddPrefix(path string) string {
+	if !strings.HasPrefix(path, Prefix) {
+		if strings.HasPrefix(path, `\\`) {
+			// This is a UNC path, so we need to add 'UNC' to the path as well.
+			path = Prefix + `UNC` + path[1:]
+		} else {
+			path = Prefix + path
+		}
+	}
+	return path
+}

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerignore/dockerignore.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerignore/dockerignore.go
@@ -1,0 +1,65 @@
+package dockerignore
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ReadAll reads a .dockerignore file and returns the list of file patterns
+// to ignore. Note this will trim whitespace from each line as well
+// as use GO's "clean" func to get the shortest/cleanest path for each.
+func ReadAll(reader io.Reader) ([]string, error) {
+	if reader == nil {
+		return nil, nil
+	}
+
+	scanner := bufio.NewScanner(reader)
+	var excludes []string
+	currentLine := 0
+
+	utf8bom := []byte{0xEF, 0xBB, 0xBF}
+	for scanner.Scan() {
+		scannedBytes := scanner.Bytes()
+		// We trim UTF8 BOM
+		if currentLine == 0 {
+			scannedBytes = bytes.TrimPrefix(scannedBytes, utf8bom)
+		}
+		pattern := string(scannedBytes)
+		currentLine++
+		// Lines starting with # (comments) are ignored before processing
+		if strings.HasPrefix(pattern, "#") {
+			continue
+		}
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+		// normalize absolute paths to paths relative to the context
+		// (taking care of '!' prefix)
+		invert := pattern[0] == '!'
+		if invert {
+			pattern = strings.TrimSpace(pattern[1:])
+		}
+		if len(pattern) > 0 {
+			pattern = filepath.Clean(pattern)
+			pattern = filepath.ToSlash(pattern)
+			if len(pattern) > 1 && pattern[0] == '/' {
+				pattern = pattern[1:]
+			}
+		}
+		if invert {
+			pattern = "!" + pattern
+		}
+
+		excludes = append(excludes, pattern)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, errors.Wrap(err, "error reading .dockerignore")
+	}
+	return excludes, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -119,6 +119,7 @@ github.com/docker/docker/api/types/volume
 github.com/docker/docker/client
 github.com/docker/docker/errdefs
 github.com/docker/docker/pkg/homedir
+github.com/docker/docker/pkg/longpath
 # github.com/docker/docker-credential-helpers v0.7.0
 ## explicit; go 1.18
 github.com/docker/docker-credential-helpers/client
@@ -302,6 +303,7 @@ github.com/moby/buildkit/client/llb
 github.com/moby/buildkit/client/ociindex
 github.com/moby/buildkit/exporter/containerimage/exptypes
 github.com/moby/buildkit/frontend/dockerfile/command
+github.com/moby/buildkit/frontend/dockerfile/dockerignore
 github.com/moby/buildkit/frontend/dockerfile/parser
 github.com/moby/buildkit/frontend/dockerfile/shell
 github.com/moby/buildkit/frontend/gateway/client


### PR DESCRIPTION
With this PR, we will build a hash for the contents in the build context and append it to the Prebuild Hash. This will cause any changes to files under the build context to be picked up while rebuilding the workspace.

Fixes ENG-1797