### PR TITLE
Prepared documentation for using env variables in devcontainer json

### DIFF
--- a/docs/pages/developing-in-workspaces/environment-variables-in-devcontainer-json.mdx
+++ b/docs/pages/developing-in-workspaces/environment-variables-in-devcontainer-json.mdx
@@ -1,0 +1,43 @@
+---
+title: Environment variables in devcontainer.json
+sidebar_label: Environment variables in devcontainer.json
+---
+
+If you're combining ssh provider with using environment variables in your `.devcontainer.json`,
+please follow the steps below to make sure that your environment variables are properly set on the remote machine.
+
+### Steps
+
+1. Prepare a `.devcontainer.json` to include `${localEnv:<VARIABLE_NAME>}` directive.<br/>
+    Example `.devcontainer.json`:
+```json
+{
+    "name": "Node.js",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:IMAGE_VERSION"
+}
+```
+
+2. Prepare an entry in a local `.ssh/config` to include `SetEnv <VARIABLE_NAME>=<VARIABLE_VALUE>` directive.<br/>
+    Example `.ssh/config`:
+```console
+Host <REMOTE-SSH-SERVER>
+   SetEnv IMAGE_VERSION=0-18-bullseye
+```
+
+3. Log to your remote machine and in the `/etc/ssh/sshd_config` add an entry `AcceptEnv <VARIABLE_NAME>`.<br/>
+    For example:
+```console
+AcceptEnv IMAGE_VERSION
+```
+
+4. Restart ssh service on your remote machine.<br/>
+For example on Debian Linux:
+```console
+systemctl restart ssh.service
+```
+
+4. Run a `devpod up` command:
+
+```console
+devpod up <GITHUB-REPOSITORY-URL> --ide=none
+```

--- a/docs/pages/getting-started/quickstart-ssh.mdx
+++ b/docs/pages/getting-started/quickstart-ssh.mdx
@@ -34,3 +34,8 @@ A new window appears showing DevPod starting the workspace. After the workspace 
 ```
 ssh MY_WORKSPACE_NAME.devpod
 ```
+
+### Using environment variables in your .devcontainer.json
+
+If you want to use env variables e.g. for dynamic control over container image version
+please follow this instruction: [Environment variables in devcontainer.json](../developing-in-workspaces/environment-variables-in-devcontainer-json.mdx)

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -71,6 +71,10 @@ module.exports = {
         },
         {
           type: "doc",
+          id: "developing-in-workspaces/environment-variables-in-devcontainer-json",
+        },
+        {
+          type: "doc",
           id: "developing-in-workspaces/prebuild-a-workspace",
         },
         {


### PR DESCRIPTION
Fixes ENG-1729

A user encountered some problems with a setup of his workspace when using env variables in devcontainer.json and passing them through the ssh: https://github.com/loft-sh/devpod/issues/507 

I'm adding here an instruction which I send him to verify he didn't forgot about anything. 

