### PR TITLE
Make the repository flag optional if --skip-push is set for devpod build

### DIFF
--- a/cmd/agent/workspace/build.go
+++ b/cmd/agent/workspace/build.go
@@ -91,7 +91,11 @@ func (cmd *BuildCmd) Run(ctx context.Context) error {
 			return errors.Wrap(err, "build")
 		}
 
-		logger.Donef("Successfully build and pushed image %s", imageName)
+		if workspaceInfo.CLIOptions.SkipPush {
+			logger.Donef("Successfully build image %s", imageName)
+		} else {
+			logger.Donef("Successfully build and pushed image %s", imageName)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
With this PR we
1. Allow devpod build without specifying pre-build repository , if --skip-push is true
2. Update info/debug messages appropriately

Closes ENG-1855