### PR TITLE
Support _(underscores) in branch name for git repo sources

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -14,7 +14,7 @@ import (
 const CommitDelimiter string = "@sha256:"
 
 var (
-	branchRegEx = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@]+)@([a-zA-Z0-9\./-]+)$`)
+	branchRegEx = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@]+)@([a-zA-Z0-9\./\-\_]+)$`)
 	commitRegEx = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@]+)` + regexp.QuoteMeta(CommitDelimiter) + `([a-zA-Z0-9]+)$`)
 )
 

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -53,6 +53,12 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedCommit: "",
 		},
 		{
+			in:             "git@github.com/loft-sh/devpod-with-branch.git@test_branch",
+			expectedRepo:   "git@github.com/loft-sh/devpod-with-branch.git",
+			expectedBranch: "test_branch",
+			expectedCommit: "",
+		},
+		{
 			in:             "github.com/loft-sh/devpod-without-protocol-with-slash.git@user/branch",
 			expectedRepo:   "https://github.com/loft-sh/devpod-without-protocol-with-slash.git",
 			expectedBranch: "user/branch",


### PR DESCRIPTION
With this PR we are adding support for "_" (underscores) in branch name for workspace source specified in <git-repository>@<branch-name> format.

Fixes #600 
Closes ENG-1853