### PR TITLE
fix(cli): check both cli options and devcontainer customizations for …

### DIFF
--- a/cmd/agent/workspace/build.go
+++ b/cmd/agent/workspace/build.go
@@ -2,7 +2,6 @@ package workspace
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/loft-sh/devpod/cmd/flags"
@@ -49,11 +48,6 @@ func (cmd *BuildCmd) Run(ctx context.Context) error {
 		return err
 	} else if shouldExit {
 		return nil
-	}
-
-	// check if repository is set
-	if workspaceInfo.CLIOptions.Repository == "" {
-		return fmt.Errorf("repository needs to be specified")
 	}
 
 	// make sure daemon does shut us down while we are doing things

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -103,7 +103,6 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 	buildCmd.Flags().StringVar(&cmd.Repository, "repository", "", "The repository to push to")
 	buildCmd.Flags().StringSliceVar(&cmd.Platform, "platform", []string{}, "Set target platform for build")
 	buildCmd.Flags().BoolVar(&cmd.SkipPush, "skip-push", false, "If true will not push the image to the repository, useful for testing")
-	_ = buildCmd.MarkFlagRequired("repository")
 
 	// TESTING
 	buildCmd.Flags().BoolVar(&cmd.ForceBuild, "force-build", false, "TESTING ONLY")

--- a/pkg/devcontainer/prebuild.go
+++ b/pkg/devcontainer/prebuild.go
@@ -15,6 +15,10 @@ func (r *Runner) Build(ctx context.Context, options config.BuildOptions) (string
 		return "", err
 	}
 
+	if options.Repository == "" && len(config.GetDevPodCustomizations(substitutedConfig.Config).PrebuildRepository) == 0 {
+		return "", fmt.Errorf("repository needs to be specified")
+	}
+
 	// check if we need to build container
 	buildInfo, err := r.build(ctx, substitutedConfig, options)
 	if err != nil {


### PR DESCRIPTION
makes `--repository` optional for `devpod build` and defers the prebuild repository check until after we parsed the `devcontainer.json` to ensure we also look for the customization