### PR TITLE
fix: Support Ports and EnvFrom in kubernetes manifest

### DIFF
--- a/pkg/driver/kubernetes/run.go
+++ b/pkg/driver/kubernetes/run.go
@@ -297,6 +297,8 @@ func getContainers(pod *corev1.Pod, imageName, entrypoint string, args []string,
 	}
 	if existingDevPodContainer != nil {
 		devPodContainer.Env = append(existingDevPodContainer.Env, devPodContainer.Env...)
+		devPodContainer.EnvFrom = existingDevPodContainer.EnvFrom
+		devPodContainer.Ports = existingDevPodContainer.Ports
 		devPodContainer.VolumeMounts = append(existingDevPodContainer.VolumeMounts, devPodContainer.VolumeMounts...)
 	}
 	retContainers = append(retContainers, devPodContainer)


### PR DESCRIPTION
PR #547 added support for a `podManifestTemplate` which claimed to fix Issue #390 (although not via `portsAttributes` but via the template).

I suspect `ports` in the manifest worked in that PR and were broken by https://github.com/loft-sh/devpod/commit/4be34b237a9653630ae687453b72117908bdc854 which did some good refactoring, but made it necessary to copy the parameters you wanted rather than basing the pod on the manifest directly.

I would like both `ports:` and `envFrom:` to work, and this commit fixes both of those to come from the template. If they are unspecified in the manifest they will be unset in the created pod too.