### PR TITLE
Image from docker compose file

### DIFF
--- a/e2e/tests/build/build.go
+++ b/e2e/tests/build/build.go
@@ -98,6 +98,27 @@ var _ = DevPodDescribe("devpod build test suite", func() {
 		framework.ExpectNoError(err)
 	})
 
+	ginkgo.It("should build the image of the referenced service from the docker compose file", func() {
+		ctx := context.Background()
+
+		f := framework.NewDefaultFramework(initialDir + "/bin")
+		tempDir, err := framework.CopyToTempDir("tests/build/testdata/docker-compose")
+		framework.ExpectNoError(err)
+		ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+		_ = f.DevPodProviderDelete(ctx, "docker")
+		err = f.DevPodProviderAdd(ctx, "docker")
+		framework.ExpectNoError(err)
+		err = f.DevPodProviderUse(context.Background(), "docker")
+		framework.ExpectNoError(err)
+
+		prebuildRepo := "test-repo"
+
+		// do the build
+		err = f.DevPodBuild(ctx, tempDir, "--repository", prebuildRepo, "--skip-push")
+		framework.ExpectNoError(err)
+	})
+
 	ginkgo.It("build docker internal buildkit", func() {
 		ctx := context.Background()
 

--- a/e2e/tests/build/testdata/docker-compose/.devcontainer/Dockerfile
+++ b/e2e/tests/build/testdata/docker-compose/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine

--- a/e2e/tests/build/testdata/docker-compose/.devcontainer/devcontainer.json
+++ b/e2e/tests/build/testdata/docker-compose/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+	"name": "Build Example",
+	"dockerComposeFile": [
+        "docker-compose.yaml"
+    ],
+	"service": "test-service"
+}

--- a/e2e/tests/build/testdata/docker-compose/.devcontainer/docker-compose.yaml
+++ b/e2e/tests/build/testdata/docker-compose/.devcontainer/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+  test-service:
+    image: test-repo:latest
+    build:
+      context: ./
+      dockerfile: Dockerfile

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -823,3 +823,7 @@ func mappingToMap(mapping composetypes.MappingWithEquals) map[string]string {
 	}
 	return ret
 }
+
+func isDockerComposeConfig(config *config.DevContainerConfig) bool {
+	return len(config.DockerComposeFile) > 0
+}

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -158,7 +158,7 @@ func (r *Runner) Up(ctx context.Context, options UpOptions) (*config.Result, err
 		if err != nil {
 			return nil, err
 		}
-	} else if len(substitutedConfig.Config.DockerComposeFile) > 0 {
+	} else if isDockerComposeConfig(substitutedConfig.Config) {
 		result, err = r.runDockerCompose(ctx, substitutedConfig, options)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
With this PR, we enable devpod build to fetch the image name of the referenced service from the service definition in docker-compose file.

P.S. Subsequently pushing the above image is not possible currently and would be discussed and worked upon

Closes ENG-1866
Closes #606 