### PR TITLE
Add composeGlobalArgs to Devpod Stop and Delete commands

### DIFF
--- a/e2e/tests/up/testdata/docker-compose-rebuild-fail/fail.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-compose-rebuild-fail/fail.devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Go",
-	"dockerComposeFile": "./docker-compose",
-	"service": "app",
+	"dockerComposeFile": "./docker-compose.yaml",
+	"service": "app1",
 	"workspaceFolder": "/workspaces"
 }

--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -114,8 +114,12 @@ func (h *ComposeHelper) Run(ctx context.Context, args []string, stdin io.Reader,
 	return cmd.Run()
 }
 
-func (h *ComposeHelper) Stop(ctx context.Context, projectName string) error {
-	out, err := h.buildCmd(ctx, "--project-name", projectName, "stop").CombinedOutput()
+func (h *ComposeHelper) Stop(ctx context.Context, projectName string, args []string) error {
+	buildArgs := []string{"--project-name", projectName}
+	buildArgs = append(buildArgs, args...)
+	buildArgs = append(buildArgs, "stop")
+
+	out, err := h.buildCmd(ctx, buildArgs...).CombinedOutput()
 	if err != nil {
 		return errors.Wrapf(err, "%s", string(out))
 	}
@@ -123,8 +127,12 @@ func (h *ComposeHelper) Stop(ctx context.Context, projectName string) error {
 	return nil
 }
 
-func (h *ComposeHelper) Remove(ctx context.Context, projectName string) error {
-	out, err := h.buildCmd(ctx, "--project-name", projectName, "down").CombinedOutput()
+func (h *ComposeHelper) Remove(ctx context.Context, projectName string, args []string) error {
+	buildArgs := []string{"--project-name", projectName}
+	buildArgs = append(buildArgs, args...)
+	buildArgs = append(buildArgs, "down")
+
+	out, err := h.buildCmd(ctx, buildArgs...).CombinedOutput()
 	if err != nil {
 		return errors.Wrapf(err, "%s", string(out))
 	}


### PR DESCRIPTION
With this PR, we add the compose files and env files paths to the devpod stop and delete commands so that they can be run regardless of the location of docker-compose.yaml .

Closes ENG-1910
Closes #623 