### PR TITLE
import workspace cmd arguments

### DIFF
--- a/cmd/provider/import_workspace.go
+++ b/cmd/provider/import_workspace.go
@@ -20,9 +20,9 @@ type ImportCmd struct {
 	WorkspaceId      string
 	WorkspaceUid     string
 	WorkspaceContext string
-	WorkspaceFolder  string
-	ProviderId       string
+	DevPodProUrl     string
 	WorkspaceOptions []string
+	providerResolver *ProviderResolver
 	log              log.Logger
 }
 
@@ -44,14 +44,13 @@ func NewImportCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	importCmd.Flags().StringVar(&cmd.WorkspaceId, "workspace-id", "", "ID of a workspace to import")
 	importCmd.Flags().StringVar(&cmd.WorkspaceUid, "workspace-uid", "", "UID of a workspace to import")
 	importCmd.Flags().StringVar(&cmd.WorkspaceContext, "workspace-context", "", "Target context for a workspace")
-	importCmd.Flags().StringVar(
-		&cmd.ProviderId, "provider-id", "", "Provider to use for importing. Must be a proxy provider")
+	importCmd.Flags().StringVar(&cmd.DevPodProUrl, "devpod-pro-url", "", "URL of a DevPod Pro containing the workspace")
 	importCmd.Flags().StringArrayVarP(
 		&cmd.WorkspaceOptions, "option", "o", []string{}, "Workspace option in the form KEY=VALUE")
 
 	_ = importCmd.MarkFlagRequired("workspace-id")
 	_ = importCmd.MarkFlagRequired("workspace-uid")
-	_ = importCmd.MarkFlagRequired("provider-id")
+	_ = importCmd.MarkFlagRequired("devpod-pro-url")
 
 	return importCmd
 }
@@ -68,7 +67,8 @@ func (cmd *ImportCmd) context(devPodConfig *config.Config) (string, error) {
 	return "", fmt.Errorf("context '%s' doesn't exist", cmd.WorkspaceContext)
 }
 
-func (cmd *ImportCmd) prepareWorkspaceToImportDefinition(devPodConfig *config.Config) (*provider2.Workspace, error) {
+func (cmd *ImportCmd) prepareWorkspaceToImportDefinition(
+	devPodConfig *config.Config, provider *provider2.ProviderConfig) (*provider2.Workspace, error) {
 	workspaceContext, err := cmd.context(devPodConfig)
 	if err != nil {
 		return nil, err
@@ -76,26 +76,27 @@ func (cmd *ImportCmd) prepareWorkspaceToImportDefinition(devPodConfig *config.Co
 
 	workspaceFolder, err := provider2.GetWorkspaceDir(workspaceContext, cmd.WorkspaceId)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "get workspace dir")
 	}
 
 	return &provider2.Workspace{
 		ID:       cmd.WorkspaceId,
 		UID:      cmd.WorkspaceUid,
 		Folder:   workspaceFolder,
-		Provider: provider2.WorkspaceProviderConfig{Name: cmd.ProviderId},
+		Provider: provider2.WorkspaceProviderConfig{Name: provider.Name},
 		Context:  workspaceContext,
 	}, nil
 }
 
 func (cmd *ImportCmd) Run(ctx context.Context, args []string) error {
-	devPodConfig, err := config.LoadConfig(cmd.Context, cmd.ProviderId)
+	devPodConfig, err := config.LoadConfig(cmd.Context, "")
 	if err != nil {
 		return err
 	}
-	proxyProvider, err := cmd.getProxyProvider(devPodConfig, cmd.ProviderId)
+
+	provider, err := cmd.providerResolver.Resolve(devPodConfig, cmd.DevPodProUrl)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "resolve provider")
 	}
 
 	options, err := provider2.ParseOptions(cmd.WorkspaceOptions)
@@ -103,13 +104,13 @@ func (cmd *ImportCmd) Run(ctx context.Context, args []string) error {
 		return errors.Wrap(err, "parse options")
 	}
 
-	workspaceDefinition, err := cmd.prepareWorkspaceToImportDefinition(devPodConfig)
+	workspaceDefinition, err := cmd.prepareWorkspaceToImportDefinition(devPodConfig, provider)
 	if err != nil {
 		return err
 	}
 
 	workspaceClient, err := clientimplementation.NewProxyClient(
-		devPodConfig, proxyProvider, workspaceDefinition, cmd.log)
+		devPodConfig, provider, workspaceDefinition, cmd.log)
 	if err != nil {
 		return err
 	}
@@ -117,11 +118,31 @@ func (cmd *ImportCmd) Run(ctx context.Context, args []string) error {
 	return workspaceClient.ImportWorkspace(ctx, options)
 }
 
-func (cmd *ImportCmd) getProxyProvider(devpodConfig *config.Config, providerID string) (*provider2.ProviderConfig, error) {
-	provider, err := workspace.FindProvider(devpodConfig, providerID, cmd.log)
+type ProviderResolver struct {
+	log log.Logger
+}
+
+func (r *ProviderResolver) proInstance(
+	devPodConfig *config.Config, devPodProUrl string) (*provider2.ProInstance, error) {
+	instances, err := workspace.ListProInstances(devPodConfig, r.log)
 	if err != nil {
-		return nil, errors.Wrap(err, "find provider")
+		return nil, errors.Wrap(err, "list pro instances")
 	}
+	for _, instance := range instances {
+		if instance.URL == devPodProUrl {
+			return instance, nil
+		}
+	}
+	return nil, fmt.Errorf("pro instance with url '%s' doesn't exist", devPodProUrl)
+}
+
+func (r *ProviderResolver) Resolve(devPodConfig *config.Config, devPodProUrl string) (*provider2.ProviderConfig, error) {
+	instance, err := r.proInstance(devPodConfig, devPodProUrl)
+	if err != nil {
+		return nil, errors.Wrap(err, "pro instance")
+	}
+
+	provider, err := workspace.FindProvider(devPodConfig, instance.ID, r.log)
 
 	if !provider.Config.IsProxyProvider() {
 		return nil, fmt.Errorf("provider is not a proxy provider")

--- a/cmd/provider/import_workspace.go
+++ b/cmd/provider/import_workspace.go
@@ -44,7 +44,6 @@ func NewImportCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	importCmd.Flags().StringVar(&cmd.WorkspaceId, "workspace-id", "", "ID of a workspace to import")
 	importCmd.Flags().StringVar(&cmd.WorkspaceUid, "workspace-uid", "", "UID of a workspace to import")
 	importCmd.Flags().StringVar(&cmd.WorkspaceContext, "workspace-context", "", "Target context for a workspace")
-	importCmd.Flags().StringVar(&cmd.WorkspaceFolder, "workspace-folder", "", "Path to the directory for a new workspace")
 	importCmd.Flags().StringVar(
 		&cmd.ProviderId, "provider-id", "", "Provider to use for importing. Must be a proxy provider")
 	importCmd.Flags().StringArrayVarP(
@@ -53,7 +52,6 @@ func NewImportCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	_ = importCmd.MarkFlagRequired("workspace-id")
 	_ = importCmd.MarkFlagRequired("workspace-uid")
 	_ = importCmd.MarkFlagRequired("provider-id")
-	_ = importCmd.MarkFlagRequired("workspace-folder")
 
 	return importCmd
 }
@@ -76,10 +74,15 @@ func (cmd *ImportCmd) prepareWorkspaceToImportDefinition(devPodConfig *config.Co
 		return nil, err
 	}
 
+	workspaceFolder, err := provider2.GetWorkspaceDir(workspaceContext, cmd.WorkspaceId)
+	if err != nil {
+		return nil, err
+	}
+
 	return &provider2.Workspace{
 		ID:       cmd.WorkspaceId,
 		UID:      cmd.WorkspaceUid,
-		Folder:   cmd.WorkspaceFolder,
+		Folder:   workspaceFolder,
 		Provider: provider2.WorkspaceProviderConfig{Name: cmd.ProviderId},
 		Context:  workspaceContext,
 	}, nil

--- a/cmd/provider/import_workspace.go
+++ b/cmd/provider/import_workspace.go
@@ -28,9 +28,11 @@ type ImportCmd struct {
 
 // NewImportCmd creates a new command
 func NewImportCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	logger := log.GetInstance()
 	cmd := &ImportCmd{
-		GlobalFlags: globalFlags,
-		log:         log.GetInstance(),
+		GlobalFlags:      globalFlags,
+		providerResolver: &ProviderResolver{log: logger},
+		log:              logger,
 	}
 
 	importCmd := &cobra.Command{
@@ -43,8 +45,9 @@ func NewImportCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 
 	importCmd.Flags().StringVar(&cmd.WorkspaceId, "workspace-id", "", "ID of a workspace to import")
 	importCmd.Flags().StringVar(&cmd.WorkspaceUid, "workspace-uid", "", "UID of a workspace to import")
-	importCmd.Flags().StringVar(&cmd.WorkspaceContext, "workspace-context", "", "Target context for a workspace")
 	importCmd.Flags().StringVar(&cmd.DevPodProUrl, "devpod-pro-url", "", "URL of a DevPod Pro containing the workspace")
+	// optional
+	importCmd.Flags().StringVar(&cmd.WorkspaceContext, "workspace-context", "", "Target context for a workspace")
 	importCmd.Flags().StringArrayVarP(
 		&cmd.WorkspaceOptions, "option", "o", []string{}, "Workspace option in the form KEY=VALUE")
 

--- a/cmd/provider/import_workspace.go
+++ b/cmd/provider/import_workspace.go
@@ -146,6 +146,9 @@ func (r *ProviderResolver) Resolve(devPodConfig *config.Config, devPodProUrl str
 	}
 
 	provider, err := workspace.FindProvider(devPodConfig, instance.ID, r.log)
+	if err != nil {
+		return nil, errors.Wrap(err, "find provider")
+	}
 
 	if !provider.Config.IsProxyProvider() {
 		return nil, fmt.Errorf("provider is not a proxy provider")

--- a/cmd/provider/import_workspace.go
+++ b/cmd/provider/import_workspace.go
@@ -58,15 +58,22 @@ func NewImportCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	return importCmd
 }
 
-func (cmd *ImportCmd) prepareWorkspaceToImportDefinition(devPodConfig *config.Config) (*provider2.Workspace, error) {
-	var workspaceContext string
-
+func (cmd *ImportCmd) context(devPodConfig *config.Config) (string, error) {
 	if cmd.WorkspaceContext == "" {
-		workspaceContext = devPodConfig.DefaultContext
-	} else if devPodConfig.Contexts[cmd.WorkspaceContext] != nil {
-		workspaceContext = cmd.WorkspaceContext
-	} else {
-		return nil, fmt.Errorf("context '%s' doesn't exist", cmd.WorkspaceContext)
+		return devPodConfig.DefaultContext, nil
+	}
+
+	if devPodConfig.Contexts[cmd.WorkspaceContext] != nil {
+		return cmd.WorkspaceContext, nil
+	}
+
+	return "", fmt.Errorf("context '%s' doesn't exist", cmd.WorkspaceContext)
+}
+
+func (cmd *ImportCmd) prepareWorkspaceToImportDefinition(devPodConfig *config.Config) (*provider2.Workspace, error) {
+	workspaceContext, err := cmd.context(devPodConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	return &provider2.Workspace{


### PR DESCRIPTION
- moved context resolving to separate method
- resolve workspace folder based on other arguments instead of flag
- prepared provider resolver to take care of finding exact provider
- moved Run command up
- cleanup of flags
