### PR TITLE
fix(desktop): add updater back to tauri features

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 # Tauri
 tauri = { version = "1.2.4", features = [
+        "updater",
         "process-relaunch",
         "window-close",
         "notification-all",


### PR DESCRIPTION
I'm trying to package DevPod Desktop with Nix, and building it as regular Rust program with `cargo build` instead of `tauri build` is simpler, but I got this error:

```
The `tauri` dependency features on the `Cargo.toml` file does not match the allowlist defined under `tauri.conf.json`.
Please run `tauri dev` or `tauri build` or add the `updater` feature.
```

It was removed in #616

This Nix PR is here if you'd like to have a look: NixOS/nixpkgs#251858