### PR TITLE
Support checkout from PR Reference

### DIFF
--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -107,6 +107,24 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 		framework.ExpectNoError(err)
 	})
 
+	ginkgo.It("should allow checkout of a GitRepo from a pull request reference", func() {
+		ctx := context.Background()
+		f := framework.NewDefaultFramework(initialDir + "/bin")
+
+		_ = f.DevPodProviderDelete(ctx, "docker")
+		err := f.DevPodProviderAdd(ctx, "docker")
+		framework.ExpectNoError(err)
+		err = f.DevPodProviderUse(ctx, "docker")
+		framework.ExpectNoError(err)
+
+		name := "devpod"
+		ginkgo.DeferCleanup(f.DevPodWorkspaceDelete, context.Background(), name)
+
+		// Wait for devpod workspace to come online (deadline: 30s)
+		err = f.DevPodUp(ctx, "github.com/loft-sh/devpod@pull/3/head")
+		framework.ExpectNoError(err)
+	})
+
 	ginkgo.It("run devpod in Kubernetes", func() {
 		ctx := context.Background()
 		f := framework.NewDefaultFramework(initialDir + "/bin")

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -8,86 +8,136 @@ import (
 )
 
 type testCaseNormalizeRepository struct {
+	in                  string
+	expectedPRReference string
+	expectedRepo        string
+	expectedBranch      string
+	expectedCommit      string
+}
+
+type testCaseGetBranchNameForPR struct {
 	in             string
-	expectedRepo   string
 	expectedBranch string
-	expectedCommit string
 }
 
 func TestNormalizeRepository(t *testing.T) {
 	testCases := []testCaseNormalizeRepository{
 		{
-			in:             "ssh://github.com/loft-sh/devpod.git",
-			expectedRepo:   "ssh://github.com/loft-sh/devpod.git",
-			expectedBranch: "",
-			expectedCommit: "",
+			in:                  "ssh://github.com/loft-sh/devpod.git",
+			expectedRepo:        "ssh://github.com/loft-sh/devpod.git",
+			expectedPRReference: "",
+			expectedBranch:      "",
+			expectedCommit:      "",
 		},
 		{
-			in:             "git@github.com/loft-sh/devpod-without-branch.git",
-			expectedRepo:   "git@github.com/loft-sh/devpod-without-branch.git",
-			expectedBranch: "",
-			expectedCommit: "",
+			in:                  "git@github.com/loft-sh/devpod-without-branch.git",
+			expectedRepo:        "git@github.com/loft-sh/devpod-without-branch.git",
+			expectedPRReference: "",
+			expectedBranch:      "",
+			expectedCommit:      "",
 		},
 		{
-			in:             "https://github.com/loft-sh/devpod.git",
-			expectedRepo:   "https://github.com/loft-sh/devpod.git",
-			expectedBranch: "",
-			expectedCommit: "",
+			in:                  "https://github.com/loft-sh/devpod.git",
+			expectedRepo:        "https://github.com/loft-sh/devpod.git",
+			expectedPRReference: "",
+			expectedBranch:      "",
+			expectedCommit:      "",
 		},
 		{
-			in:             "github.com/loft-sh/devpod.git",
-			expectedRepo:   "https://github.com/loft-sh/devpod.git",
-			expectedBranch: "",
-			expectedCommit: "",
+			in:                  "github.com/loft-sh/devpod.git",
+			expectedRepo:        "https://github.com/loft-sh/devpod.git",
+			expectedPRReference: "",
+			expectedBranch:      "",
+			expectedCommit:      "",
 		},
 		{
-			in:             "github.com/loft-sh/devpod.git@test-branch",
-			expectedRepo:   "https://github.com/loft-sh/devpod.git",
-			expectedBranch: "test-branch",
-			expectedCommit: "",
+			in:                  "github.com/loft-sh/devpod.git@test-branch",
+			expectedRepo:        "https://github.com/loft-sh/devpod.git",
+			expectedPRReference: "",
+			expectedBranch:      "test-branch",
+			expectedCommit:      "",
 		},
 		{
-			in:             "git@github.com/loft-sh/devpod-with-branch.git@test-branch",
-			expectedRepo:   "git@github.com/loft-sh/devpod-with-branch.git",
-			expectedBranch: "test-branch",
-			expectedCommit: "",
+			in:                  "git@github.com/loft-sh/devpod-with-branch.git@test-branch",
+			expectedRepo:        "git@github.com/loft-sh/devpod-with-branch.git",
+			expectedPRReference: "",
+			expectedBranch:      "test-branch",
+			expectedCommit:      "",
 		},
 		{
-			in:             "git@github.com/loft-sh/devpod-with-branch.git@test_branch",
-			expectedRepo:   "git@github.com/loft-sh/devpod-with-branch.git",
-			expectedBranch: "test_branch",
-			expectedCommit: "",
+			in:                  "git@github.com/loft-sh/devpod-with-branch.git@test_branch",
+			expectedRepo:        "git@github.com/loft-sh/devpod-with-branch.git",
+			expectedPRReference: "",
+			expectedBranch:      "test_branch",
+			expectedCommit:      "",
 		},
 		{
-			in:             "github.com/loft-sh/devpod-without-protocol-with-slash.git@user/branch",
-			expectedRepo:   "https://github.com/loft-sh/devpod-without-protocol-with-slash.git",
-			expectedBranch: "user/branch",
-			expectedCommit: "",
+			in:                  "github.com/loft-sh/devpod-without-protocol-with-slash.git@user/branch",
+			expectedRepo:        "https://github.com/loft-sh/devpod-without-protocol-with-slash.git",
+			expectedPRReference: "",
+			expectedBranch:      "user/branch",
+			expectedCommit:      "",
 		},
 		{
-			in:             "git@github.com/loft-sh/devpod-with-slash.git@user/branch",
-			expectedRepo:   "git@github.com/loft-sh/devpod-with-slash.git",
-			expectedBranch: "user/branch",
-			expectedCommit: "",
+			in:                  "git@github.com/loft-sh/devpod-with-slash.git@user/branch",
+			expectedRepo:        "git@github.com/loft-sh/devpod-with-slash.git",
+			expectedPRReference: "",
+			expectedBranch:      "user/branch",
+			expectedCommit:      "",
 		},
 		{
-			in:             "github.com/loft-sh/devpod.git@sha256:905ffb0",
-			expectedRepo:   "https://github.com/loft-sh/devpod.git",
-			expectedBranch: "",
-			expectedCommit: "905ffb0",
+			in:                  "github.com/loft-sh/devpod.git@sha256:905ffb0",
+			expectedRepo:        "https://github.com/loft-sh/devpod.git",
+			expectedPRReference: "",
+			expectedBranch:      "",
+			expectedCommit:      "905ffb0",
 		},
 		{
-			in:             "git@github.com:loft-sh/devpod.git@sha256:905ffb0",
-			expectedRepo:   "git@github.com:loft-sh/devpod.git",
-			expectedBranch: "",
-			expectedCommit: "905ffb0",
+			in:                  "git@github.com:loft-sh/devpod.git@sha256:905ffb0",
+			expectedRepo:        "git@github.com:loft-sh/devpod.git",
+			expectedPRReference: "",
+			expectedBranch:      "",
+			expectedCommit:      "905ffb0",
+		},
+		{
+			in:                  "github.com/loft-sh/devpod.git@pull/996/head",
+			expectedRepo:        "https://github.com/loft-sh/devpod.git",
+			expectedPRReference: "pull/996/head",
+			expectedBranch:      "",
+			expectedCommit:      "",
+		},
+		{
+			in:                  "git@github.com:loft-sh/devpod.git@pull/996/head",
+			expectedRepo:        "git@github.com:loft-sh/devpod.git",
+			expectedPRReference: "pull/996/head",
+			expectedBranch:      "",
+			expectedCommit:      "",
 		},
 	}
 
 	for _, testCase := range testCases {
-		outRepo, outBranch, outCommit := NormalizeRepository(testCase.in)
+		outRepo, outPRReference, outBranch, outCommit := NormalizeRepository(testCase.in)
 		assert.Check(t, cmp.Equal(testCase.expectedRepo, outRepo))
+		assert.Check(t, cmp.Equal(testCase.expectedPRReference, outPRReference))
 		assert.Check(t, cmp.Equal(testCase.expectedBranch, outBranch))
 		assert.Check(t, cmp.Equal(testCase.expectedCommit, outCommit))
+	}
+}
+
+func TestGetBranchNameForPRReference(t *testing.T) {
+	testCases := []testCaseGetBranchNameForPR{
+		{
+			in:             "pull/996/head",
+			expectedBranch: "PR996",
+		},
+		{
+			in:             "pull/abc/head",
+			expectedBranch: "pull/abc/head",
+		},
+	}
+
+	for _, testCase := range testCases {
+		outBranch := GetBranchNameForPR(testCase.in)
+		assert.Check(t, cmp.Equal(testCase.expectedBranch, outBranch))
 	}
 }

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -96,6 +96,9 @@ type WorkspaceSource struct {
 	// GitCommit is the commit SHA to checkout
 	GitCommit string `json:"gitCommit,omitempty"`
 
+	// GitPRReference is the pull request reference to checkout
+	GitPRReference string `json:"gitPRReference,omitempty"`
+
 	// LocalFolder is the local folder to use
 	LocalFolder string `json:"localFolder,omitempty"`
 
@@ -153,7 +156,9 @@ type CLIOptions struct {
 
 func (w WorkspaceSource) String() string {
 	if w.GitRepository != "" {
-		if w.GitBranch != "" {
+		if w.GitPRReference != "" {
+			return WorkspaceSourceGit + w.GitRepository + "@" + w.GitPRReference
+		} else if w.GitBranch != "" {
 			return WorkspaceSourceGit + w.GitRepository + "@" + w.GitBranch
 		} else if w.GitCommit != "" {
 			return WorkspaceSourceGit + w.GitRepository + git.CommitDelimiter + w.GitCommit
@@ -171,11 +176,12 @@ func (w WorkspaceSource) String() string {
 
 func ParseWorkspaceSource(source string) *WorkspaceSource {
 	if strings.HasPrefix(source, WorkspaceSourceGit) {
-		gitRepo, gitBranch, gitCommit := git.NormalizeRepository(strings.TrimPrefix(source, WorkspaceSourceGit))
+		gitRepo, gitPRReference, gitBranch, gitCommit := git.NormalizeRepository(strings.TrimPrefix(source, WorkspaceSourceGit))
 		return &WorkspaceSource{
-			GitRepository: gitRepo,
-			GitBranch:     gitBranch,
-			GitCommit:     gitCommit,
+			GitRepository:  gitRepo,
+			GitPRReference: gitPRReference,
+			GitBranch:      gitBranch,
+			GitCommit:      gitCommit,
 		}
 	} else if strings.HasPrefix(source, WorkspaceSourceLocal) {
 		return &WorkspaceSource{


### PR DESCRIPTION
With this PR we support checkout from a PR Reference, so that below should be possible now.

```devpod up <repo-name>@pull/<PR-number>/head```


Closes ENG-1842