### PR TITLE
improvements to error handling in import-workspace

### DIFF
--- a/cmd/pro/import_workspace.go
+++ b/cmd/pro/import_workspace.go
@@ -77,7 +77,7 @@ func (cmd *ImportCmd) Run(ctx context.Context, args []string) error {
 
 	workspaceDefinition, err := cmd.prepareWorkspaceToImportDefinition(devPodConfig, provider)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "prepare workspace to import definition")
 	}
 
 	workspaceClient, err := clientimplementation.NewProxyClient(

--- a/desktop/src/useAppReady.tsx
+++ b/desktop/src/useAppReady.tsx
@@ -174,7 +174,8 @@ export function useAppReady() {
               options: event.options,
             })
             if (importResult.err) {
-              setFailedMessage("Failed to import workspace")
+              // todo: remove debug line
+              setFailedMessage("Failed to import workspace: " + importResult.val.message)
 
               return
             }
@@ -184,7 +185,7 @@ export function useAppReady() {
             }
             const maybeWorkspace = workspacesResult.val.find((w) => w.id === event.workspace_id)
             if (!maybeWorkspace) {
-              setFailedMessage("Failed to import workspace")
+              setFailedMessage("Could not find workspace after import")
 
               return
             }

--- a/desktop/src/useAppReady.tsx
+++ b/desktop/src/useAppReady.tsx
@@ -174,8 +174,8 @@ export function useAppReady() {
               options: event.options,
             })
             if (importResult.err) {
-              // todo: remove debug line
-              setFailedMessage("Failed to import workspace: " + importResult.val.message)
+              const cleanedMsg = importResult.val.message.split("\n").at(-1) ?? "";
+              setFailedMessage("Failed to import workspace: " + cleanedMsg)
 
               return
             }

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -343,10 +343,15 @@ func (s *proxyClient) ImportWorkspace(ctx context.Context, options client.Import
 		readLogStream(reader, s.log)
 	}()
 
+	cmd := s.config.Exec.Proxy.ImportWorkspace
+	if !isCommandSpecified(cmd) {
+		return fmt.Errorf("import command not configured")
+	}
+
 	err := RunCommandWithBinaries(
 		ctx,
 		"import",
-		s.config.Exec.Proxy.ImportWorkspace,
+		cmd,
 		s.workspace.Context,
 		s.workspace,
 		nil,
@@ -363,6 +368,10 @@ func (s *proxyClient) ImportWorkspace(ctx context.Context, options client.Import
 	}
 
 	return nil
+}
+
+func isCommandSpecified(cmd []string) bool {
+	return len(cmd) > 0 && cmd[0] != ""
 }
 
 func EncodeOptions(options any, name string) map[string]string {

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -365,7 +365,7 @@ func (s *proxyClient) ImportWorkspace(ctx context.Context, options client.Import
 		msg, parsingError := parseLogEntry(cmdOutput)
 		if parsingError != nil {
 			s.log.Warnf("Error parsing log entry (%v): %v", cmdOutput, parsingError)
-			return fmt.Errorf("error importing a workspace: %s", err)
+			return fmt.Errorf("error importing a workspace: %w", err)
 		}
 
 		return fmt.Errorf("error importing a workspace: %s", msg)


### PR DESCRIPTION
Resolves ENG-1992 


Message for invalid devpod pro host:

<img width="532" alt="Screenshot 2023-09-05 at 13 28 59" src="https://github.com/loft-sh/devpod/assets/18076988/f08d3c91-db28-4db6-9fd2-7ddf29f4e78c">

Message for not-existing workspace:
<img width="568" alt="Screenshot 2023-09-05 at 13 29 45" src="https://github.com/loft-sh/devpod/assets/18076988/6e1608d1-68d6-44d4-9721-83cf82618705">

Unsupported host:
<img width="525" alt="Screenshot 2023-09-05 at 14 01 46" src="https://github.com/loft-sh/devpod/assets/18076988/3724c424-bf9e-4f3a-aeb8-e17852d1284f">




There is one last case which left - if we lack some id / parameter, we get only "invalid query" error. I spend some time debugging it, but couldn't figure out why the message is not passed to the UI. I'll spend some more time on that, but don't want to block the whole process by only this one case.


