### PR TITLE
Small fixes to force-build

### DIFF
--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -103,7 +103,7 @@ func (r *runner) extendImage(ctx context.Context, parsedConfig *config.Substitut
 	}
 
 	// get extend image build info
-	extendedBuildInfo, err := feature.GetExtendedBuildInfo(r.SubstitutionContext, imageBuildInfo.Metadata, imageBuildInfo.User, imageBase, parsedConfig, r.Log)
+	extendedBuildInfo, err := feature.GetExtendedBuildInfo(r.SubstitutionContext, imageBuildInfo.Metadata, imageBuildInfo.User, imageBase, parsedConfig, r.Log, options.ForceBuild)
 	if err != nil {
 		return nil, errors.Wrap(err, "get extended build info")
 	}
@@ -154,7 +154,7 @@ func (r *runner) buildAndExtendImage(ctx context.Context, parsedConfig *config.S
 	}
 
 	// get extend image build info
-	extendedBuildInfo, err := feature.GetExtendedBuildInfo(r.SubstitutionContext, imageBuildInfo.Metadata, imageBuildInfo.User, imageBase, parsedConfig, r.Log)
+	extendedBuildInfo, err := feature.GetExtendedBuildInfo(r.SubstitutionContext, imageBuildInfo.Metadata, imageBuildInfo.User, imageBase, parsedConfig, r.Log, options.ForceBuild)
 	if err != nil {
 		return nil, errors.Wrap(err, "get extended build info")
 	}

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -397,7 +397,7 @@ func (r *runner) buildAndExtendDockerCompose(ctx context.Context, parsedConfig *
 		}
 	}
 
-	extendImageBuildInfo, err := feature.GetExtendedBuildInfo(r.SubstitutionContext, imageBuildInfo.Metadata, imageBuildInfo.User, buildTarget, parsedConfig, r.Log)
+	extendImageBuildInfo, err := feature.GetExtendedBuildInfo(r.SubstitutionContext, imageBuildInfo.Metadata, imageBuildInfo.User, buildTarget, parsedConfig, r.Log, false)
 	if err != nil {
 		return "", "", nil, "", err
 	}
@@ -611,10 +611,10 @@ func (r *runner) generateDockerComposeUpProject(
 	entrypoint := composetypes.ShellCommand{
 		"/bin/sh",
 		"-c",
-		`echo Container started 
+		`echo Container started
 trap "exit 0" 15
-` + strings.Join(mergedConfig.Entrypoints, "\n") + ` 
-exec "$$@" 
+` + strings.Join(mergedConfig.Entrypoints, "\n") + `
+exec "$$@"
 while sleep 1 & wait $$!; do :; done`,
 		"-",
 	}

--- a/pkg/devcontainer/feature/extend.go
+++ b/pkg/devcontainer/feature/extend.go
@@ -51,8 +51,8 @@ type BuildInfo struct {
 	BuildArgs               map[string]string
 }
 
-func GetExtendedBuildInfo(substitutionContext *config.SubstitutionContext, baseImageMetadata *config.ImageMetadataConfig, user, target string, devContainerConfig *config.SubstitutedConfig, log log.Logger) (*ExtendedBuildInfo, error) {
-	features, err := fetchFeatures(devContainerConfig.Config, log)
+func GetExtendedBuildInfo(substitutionContext *config.SubstitutionContext, baseImageMetadata *config.ImageMetadataConfig, user, target string, devContainerConfig *config.SubstitutedConfig, log log.Logger, forceBuild bool) (*ExtendedBuildInfo, error) {
+	features, err := fetchFeatures(devContainerConfig.Config, log, forceBuild)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch features")
 	}
@@ -223,10 +223,10 @@ func findContainerUsers(baseImageMetadata *config.ImageMetadataConfig, composeSe
 	return containerUser, remoteUser
 }
 
-func fetchFeatures(devContainerConfig *config.DevContainerConfig, log log.Logger) ([]*config.FeatureSet, error) {
+func fetchFeatures(devContainerConfig *config.DevContainerConfig, log log.Logger, forceBuild bool) ([]*config.FeatureSet, error) {
 	featureSets := []*config.FeatureSet{}
 	for featureID, featureOptions := range devContainerConfig.Features {
-		featureFolder, err := ProcessFeatureID(featureID, filepath.Dir(devContainerConfig.Origin), log)
+		featureFolder, err := ProcessFeatureID(featureID, filepath.Dir(devContainerConfig.Origin), log, forceBuild)
 		if err != nil {
 			return nil, errors.Wrap(err, "process feature "+featureID)
 		}

--- a/pkg/devcontainer/feature/features.go
+++ b/pkg/devcontainer/feature/features.go
@@ -90,10 +90,10 @@ func escapeQuotesForShell(str string) string {
 	return strings.ReplaceAll(str, "'", `'\''`)
 }
 
-func ProcessFeatureID(id, configDir string, log log.Logger) (string, error) {
+func ProcessFeatureID(id, configDir string, log log.Logger, forceBuild bool) (string, error) {
 	if strings.HasPrefix(id, "https://") || strings.HasPrefix(id, "http://") {
 		log.Debugf("Process url feature")
-		return processDirectTarFeature(id, log)
+		return processDirectTarFeature(id, log, forceBuild)
 	} else if strings.HasPrefix(id, "./") || strings.HasPrefix(id, "../") {
 		log.Debugf("Process local feature")
 		return filepath.Abs(path.Join(filepath.ToSlash(configDir), id))
@@ -194,7 +194,7 @@ func downloadLayer(img v1.Image, id, destFile string, log log.Logger) error {
 	return nil
 }
 
-func processDirectTarFeature(id string, log log.Logger) (string, error) {
+func processDirectTarFeature(id string, log log.Logger, forceDownload bool) (string, error) {
 	downloadBase := id[strings.LastIndex(id, "/"):]
 	if !directTarballRegEx.MatchString(downloadBase) {
 		return "", fmt.Errorf("expected tarball name to follow 'devcontainer-feature-<feature-id>.tgz' format.  Received '%s' ", downloadBase)
@@ -204,7 +204,7 @@ func processDirectTarFeature(id string, log log.Logger) (string, error) {
 	featureFolder := getFeaturesTempFolder(id)
 	featureExtractedFolder := filepath.Join(featureFolder, "extracted")
 	_, err := os.Stat(featureExtractedFolder)
-	if err == nil {
+	if err == nil && !forceDownload {
 		return featureExtractedFolder, nil
 	}
 

--- a/pkg/driver/docker/build.go
+++ b/pkg/driver/docker/build.go
@@ -34,7 +34,7 @@ func (d *dockerDriver) BuildDevContainer(
 ) (*config.BuildInfo, error) {
 	// check if image build is necessary
 	imageName := GetImageName(localWorkspaceFolder, prebuildHash)
-	if options.Repository == "" {
+	if options.Repository == "" && !options.ForceBuild {
 		imageDetails, err := d.Docker.InspectImage(ctx, imageName, false)
 		if err == nil && imageDetails != nil {
 			// local image found


### PR DESCRIPTION
Two fixes for the force-build flag that is very useful when building new features
First is the build is no triggered when the flag is used without a repository (so with skip-push)
Second is to force the redownload of the package when using archive on a https server 