### PR TITLE
fail fast if mounted filesystem for agent is noexec

### DIFF
--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -113,6 +113,11 @@ func InjectAgentAndExecute(
 			log,
 		)
 		if err != nil {
+			// noexec filesystem - no need to retry
+			if errors.Is(err, inject.ErrNoExecFilesystem) {
+				return err
+			}
+
 			if time.Since(now) > waitForInstanceConnectionTimeout {
 				return errors.Wrap(err, "timeout waiting for instance connection")
 			} else if wasExecuted {

--- a/pkg/inject/filesystem_linux.go
+++ b/pkg/inject/filesystem_linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package inject
+
+import "golang.org/x/sys/unix"
+
+func isNoExec(path string) (bool, error) {
+	var stat unix.Statfs_t
+	err := unix.Statfs(path, &stat)
+	if err != nil {
+		return false, err
+	}
+
+	return stat.Flags&unix.ST_NOEXEC != 0, nil
+}

--- a/pkg/inject/filesystem_other.go
+++ b/pkg/inject/filesystem_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package inject
+
+func isNoExec(path string) (bool, error) {
+	return false, nil
+}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -76,7 +76,7 @@ func InjectAndExecute(
 	}
 
 	log.Debugf("ensure agent path's filesystem is not noexec")
-	noExec, err := isNoExec(remotePath)
+	noExec, err := isNoExec(path.Dir(remotePath))
 	if err != nil {
 		return false, perrors.Wrapf(err, "check if filesystem is noexec")
 	}


### PR DESCRIPTION
Fix ENG-2043

Tested locally by manually switching `isNoExec()` return value for mac from `false` to `true`