### PR TITLE
fix: setup-dotfiles should be ran as the default user

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -786,10 +786,10 @@ func setupDotfiles(
 		agentArguments = append(agentArguments, dotfilesScript)
 	}
 
-    remoteUser, err:= devssh.GetUser(client.Workspace())
-    if err != nil {
-        remoteUser = "root"
-    }
+	remoteUser, err := devssh.GetUser(client.Workspace())
+	if err != nil {
+		remoteUser = "root"
+	}
 
 	dotCmd := exec.Command(
 		execPath,

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -786,11 +786,18 @@ func setupDotfiles(
 		agentArguments = append(agentArguments, dotfilesScript)
 	}
 
+    remoteUser, err:= devssh.GetUser(client.Workspace())
+    if err != nil {
+        remoteUser = "root"
+    }
+
 	dotCmd := exec.Command(
 		execPath,
 		"ssh",
 		"--agent-forwarding=true",
 		"--start-services=false",
+		"--user",
+		remoteUser,
 		"--context",
 		client.Context(),
 		client.Workspace(),


### PR DESCRIPTION
This way now we will default to the container user (usually vscode) and fallback to root otherwise

Fix #655 
Resolves ENG-1975