### PR TITLE
fix: missing start-service to start the credential server

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -795,7 +795,7 @@ func setupDotfiles(
 		execPath,
 		"ssh",
 		"--agent-forwarding=true",
-		"--start-services=false",
+		"--start-services=true",
 		"--user",
 		remoteUser,
 		"--context",


### PR DESCRIPTION
Fix #620 
Resolves ENG-1900

Now we force the credential server to start, so that both SSH and Git credentials are forwarded fixing cloning on private repos