### PR TITLE
chore: refine AppImage dependencies and docs, create a tar.gz deployment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -424,6 +424,7 @@ jobs:
               { target: "darwin-aarch64", sigFile: "aarch64.app.tar.gz.sig", packageType: ".tar.gz", originalAssetName: `DevPod_${version}_aarch64.dmg`, desiredAssetName: "DevPod_macos_aarch64.dmg", originalUpdaterAssetName: "DevPod_aarch64.app.tar.gz", desiredUpdaterAssetName: "DevPod_macos_aarch64.app.tar.gz" },
               { target: "darwin-x86_64", sigFile: "x64.app.tar.gz.sig", packageType: ".tar.gz", originalAssetName: `DevPod_${version}_x64.dmg`, desiredAssetName: "DevPod_macos_x64.dmg", originalUpdaterAssetName: "DevPod_x64.app.tar.gz", desiredUpdaterAssetName: "DevPod_macos_x64.app.tar.gz" },
               { target: "windows-x86_64", sigFile: ".msi.zip.sig", packageType: ".zip", originalAssetName: `DevPod_${winVersion}_x64_en-US.msi`, desiredAssetName: "DevPod_windows_x64_en-US.msi" },
+              { originalAssetName: `dev-pod-${version}.tar.gz`, desiredAssetName: "DevPod_linux_x86_64.tar.gz" },
             ]
 
             for (const info of infos) {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,7 +200,7 @@ jobs:
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           projectPath: "./desktop"
-          args: "--config src-tauri/tauri-linux.conf.json --target ${{ matrix.settings.target }} --features enable-updater"
+          args: "--config src-tauri/tauri-linux.conf.json --target ${{ matrix.settings.target }} --features enable-updater --bundles appimage,updater"
           includeUpdaterJson: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -231,51 +231,14 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
 
-      - name: Build RPM
+      - name: Build linux tar.gz
         if: matrix.settings.host == 'ubuntu-20.04' && matrix.settings.cli_only == false
-        id: build-desktop-rpm
+        id: build-desktop-targz
         run: |
-          cd ./desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/deb/ || exit 1
+          cd ./desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/appimage/dev-pod.AppDir || exit 1
+          tar --exclude=usr/lib --exclude=usr/share/doc -zcvf dev-pod-desktop.tar.gz usr
 
-          sudo apt-get update
-          sudo apt-get install -y alien rpm
-          # Cleanup
-          rm -rf "dev-pod-${{needs.create-release.outputs.package_version}}"
-          rm -f "*.rpm"
-
-          # Convert deb to rpm
-          alien -r -g -k -v "dev-pod_${{needs.create-release.outputs.package_version}}_amd64.deb"
-
-          DEPENDENCIES="
-            libappindicator-gtk3
-            gdk-pixbuf2
-            libbsd
-            libXdmcp
-            libwmf
-            libdeflate
-            gtk3-immodules
-          "
-          rpm_version="$(echo ${{needs.create-release.outputs.package_version}} | cut -d'-' -f1)"
-
-          # Rename spec file
-          mv dev-pod-${rpm_version}/dev-pod-${{needs.create-release.outputs.package_version}}*.spec dev-pod-${rpm_version}/dev-pod-${rpm_version}.spec
-
-          # Inject missing dependencies
-          for dependency in ${DEPENDENCIES}; do
-            sed -i "s|Group: Converted/unknown|Group: Converted/unknown\nRequires: ${dependency}|g" "dev-pod-${rpm_version}/dev-pod-${rpm_version}.spec"
-          done
-
-          # Remove unwanted dirs
-          sed -i 's|^"/usr"$||g' "dev-pod-${rpm_version}/dev-pod-${rpm_version}.spec"
-          sed -i 's|^"/usr/bin"$||g' "dev-pod-${rpm_version}/dev-pod-${rpm_version}.spec"
-
-          cd "dev-pod-${rpm_version}" || exit 1
-          rpmbuild --target=x86_64 --buildroot "$(pwd)" -bb "$(pwd)/dev-pod-${rpm_version}.spec"
-
-          cd -
-          if [ ! -e dev-pod-${{needs.create-release.outputs.package_version}}.x86_64.rpm ]; then
-            mv dev-pod-${{needs.create-release.outputs.package_version}}*.x86_64.rpm dev-pod-${{needs.create-release.outputs.package_version}}.x86_64.rpm
-          fi
+          mv dev-pod-desktop.tar.gz ../../dev-pod-${{needs.create-release.outputs.package_version}}.tar.gz
 
       - name: Build Desktop App
         if: matrix.settings.host == 'windows-latest' && matrix.settings.cli_only == false
@@ -385,7 +348,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload RPM Asset
+      - name: Upload Tar.gz Asset
         if: matrix.settings.host == 'ubuntu-20.04' && matrix.settings.cli_only == false
         uses: actions/github-script@v6
         with:
@@ -393,8 +356,8 @@ jobs:
             const fs = require("fs")
 
             const releaseId = "${{ needs.create-release.outputs.release_id }}"
-            const assetName = "dev-pod-${{needs.create-release.outputs.package_version}}.x86_64.rpm"
-            const assetPath = `desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/deb/${assetName}`
+            const assetName = "dev-pod-${{needs.create-release.outputs.package_version}}.tar.gz"
+            const assetPath = `desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/${assetName}`
 
             console.log("Attempting to upload release asset: ", assetName)
 
@@ -461,8 +424,6 @@ jobs:
               { target: "darwin-aarch64", sigFile: "aarch64.app.tar.gz.sig", packageType: ".tar.gz", originalAssetName: `DevPod_${version}_aarch64.dmg`, desiredAssetName: "DevPod_macos_aarch64.dmg", originalUpdaterAssetName: "DevPod_aarch64.app.tar.gz", desiredUpdaterAssetName: "DevPod_macos_aarch64.app.tar.gz" },
               { target: "darwin-x86_64", sigFile: "x64.app.tar.gz.sig", packageType: ".tar.gz", originalAssetName: `DevPod_${version}_x64.dmg`, desiredAssetName: "DevPod_macos_x64.dmg", originalUpdaterAssetName: "DevPod_x64.app.tar.gz", desiredUpdaterAssetName: "DevPod_macos_x64.app.tar.gz" },
               { target: "windows-x86_64", sigFile: ".msi.zip.sig", packageType: ".zip", originalAssetName: `DevPod_${winVersion}_x64_en-US.msi`, desiredAssetName: "DevPod_windows_x64_en-US.msi" },
-              { originalAssetName: `dev-pod-${version}.x86_64.rpm`, desiredAssetName: "DevPod_linux_x86_64.rpm" },
-              { originalAssetName: `dev-pod_${version}_amd64.deb`, desiredAssetName: "DevPod_linux_amd64.deb" },
             ]
 
             for (const info of infos) {

--- a/docs/pages/getting-started/install.mdx
+++ b/docs/pages/getting-started/install.mdx
@@ -16,15 +16,54 @@ Download DevPod Desktop:
 - [MacOS Intel/AMD](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_macos_x64.dmg)
 - [Windows](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_windows_x64_en-US.msi)
 - [Linux AppImage](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_linux_amd64.AppImage)
-- [Linux deb](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_linux_amd64.deb)
-- [Linux rpm](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_linux_x86_64.rpm)
-
-Make sure to download the correct binary for your operating system. For Fedora, please install the following prerequisites:
-
-```sudo dnf install gtk3-immodules libappindicator-gtk3 libdeflate webkit2gtk3 libwmf```
+- [Linux Targz](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_linux_amd64.tar.gz)
 
 :::info Previous Releases
 For previous releases, please take a look at the [Github releases page](https://github.com/loft-sh/devpod/releases)
+:::
+
+:::info Linux Packages
+**The official package is the Appimage**, it has been tested working on:
+
+- Debian 11 and newer
+- Ubuntu 20.04 and newer
+- Fedora 32 and newer
+- Centos 9stream and newer
+- RHEL/Alma Linux/Rocky Linux 9 and newer
+- Opensuse Leap 15.3 and newer
+- Opensuse Tumbleweed
+- Archlinux
+
+Make sure you have the following dependencies installed for the Appimage to work (usually already installed in desktop distributions):
+
+- glibc version 2.30+
+- fuse2, fuse2 libraries, libopengl, libfribidi, libegl, libxgl
+    - `sudo apt-get install fuse libfuse2 libopengl0 libfribidi0`
+    - `sudo dnf install fuse fuse-libs libglvnd-egl libglvnd-opengl libglvnd-glx harfbuzz fontconfig fribidi libthai`
+    - `sudo zypper in fuse libfuse2 libharfbuzz0 libfribidi0 libthai0`
+
+Note that these are generally needed for AppImage to work, they are not specific to DevPod
+:::
+
+
+:::info Linux Custom Packages
+Since we're not providing deb or rpm packages anymore, we're now providing a tar.gz
+that can be used as source for your custom package.
+
+Keep in mind the following dependencies need to be declared in the package for the
+correct functioning of the program:
+
+- libappindicator3-1
+- libgdk-pixbuf2.0-0
+- libbsd0
+- libxdmcp6
+- libwmf-0.2-7
+- libwmf-0.2-7-gtk
+- libgtk-3-0
+- libwmf-dev
+- libwebkit2gtk-4.0-37
+- librust-openssl-sys-dev
+- librust-glib-sys-dev
 :::
 
 ## Optional: Install DevPod CLI


### PR DESCRIPTION
This PR deprecates the DEB and RPM Packages for linux

We'll officially support only the Appimage built by tauri

We'll also provide a tar.gz that can be used separately or for people that want to create their own packages
Also document the necessary dependencies to run the Appimage, and dependencies needed to run the tar.gz

Resolves ENG-1629
Resolves ENG-2135
