### PR TITLE
Set SSH working directory

### DIFF
--- a/cmd/helper/ssh_server.go
+++ b/cmd/helper/ssh_server.go
@@ -26,6 +26,7 @@ type SSHServerCmd struct {
 	Address       string
 	Stdio         bool
 	TrackActivity bool
+	Workdir       string
 }
 
 // NewSSHServerCmd creates a new ssh command
@@ -44,6 +45,7 @@ func NewSSHServerCmd(flags *flags.GlobalFlags) *cobra.Command {
 	sshCmd.Flags().BoolVar(&cmd.Stdio, "stdio", false, "Will listen on stdout and stdin instead of an address")
 	sshCmd.Flags().BoolVar(&cmd.TrackActivity, "track-activity", false, "If enabled will write the last activity time to a file")
 	sshCmd.Flags().StringVar(&cmd.Token, "token", "", "Base64 encoded token to use")
+	sshCmd.Flags().StringVar(&cmd.Workdir, "workdir", "", "Directory where commands will run on the host")
 	return sshCmd
 }
 
@@ -87,7 +89,7 @@ func (cmd *SSHServerCmd) Run(_ *cobra.Command, _ []string) error {
 	}
 
 	// start the server
-	server, err := helperssh.NewServer(cmd.Address, hostKey, keys, log.Default.ErrorStreamOnly())
+	server, err := helperssh.NewServer(cmd.Address, hostKey, keys, cmd.Workdir, log.Default.ErrorStreamOnly())
 	if err != nil {
 		return err
 	}

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
-	"path/filepath"
 
 	"github.com/loft-sh/devpod/cmd/flags"
 	"github.com/loft-sh/devpod/cmd/machine"

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 	"time"
+	"path/filepath"
 
 	"github.com/loft-sh/devpod/cmd/flags"
 	"github.com/loft-sh/devpod/cmd/machine"
@@ -124,7 +125,7 @@ func (cmd *SSHCmd) startProxyTunnel(ctx context.Context, devPodConfig *config.Co
 			})
 		},
 		func(ctx context.Context, containerClient *ssh.Client) error {
-			return cmd.startTunnel(ctx, devPodConfig, containerClient, client.WorkspaceConfig().IDE.Name, log)
+			return cmd.startTunnel(ctx, devPodConfig, containerClient, client.Workspace(), client.WorkspaceConfig().IDE.Name, log)
 		},
 	)
 }
@@ -191,7 +192,7 @@ func (cmd *SSHCmd) jumpContainer(ctx context.Context, devPodConfig *config.Confi
 		unlockOnce.Do(client.Unlock)
 
 		// start ssh tunnel
-		return cmd.startTunnel(ctx, devPodConfig, containerClient, client.WorkspaceConfig().IDE.Name, log)
+		return cmd.startTunnel(ctx, devPodConfig, containerClient, client.Workspace(), client.WorkspaceConfig().IDE.Name, log)
 	})
 }
 
@@ -227,7 +228,7 @@ func (cmd *SSHCmd) forwardPorts(ctx context.Context, containerClient *ssh.Client
 	return <-errChan
 }
 
-func (cmd *SSHCmd) startTunnel(ctx context.Context, devPodConfig *config.Config, containerClient *ssh.Client, ideName string, log log.Logger) error {
+func (cmd *SSHCmd) startTunnel(ctx context.Context, devPodConfig *config.Config, containerClient *ssh.Client, workspaceName string, ideName string, log log.Logger) error {
 	// check if we should forward ports
 	if len(cmd.ForwardPorts) > 0 {
 		return cmd.forwardPorts(ctx, containerClient, log)
@@ -243,7 +244,7 @@ func (cmd *SSHCmd) startTunnel(ctx context.Context, devPodConfig *config.Config,
 	defer writer.Close()
 
 	log.Debugf("Run outer container tunnel")
-	command := fmt.Sprintf("'%s' helper ssh-server --track-activity --stdio", agent.ContainerDevPodHelperLocation)
+	command := fmt.Sprintf("'%s' helper ssh-server --track-activity --stdio --workdir '%s'", agent.ContainerDevPodHelperLocation, filepath.Join("workspaces", workspaceName))
 	if cmd.Debug {
 		command += " --debug"
 	}

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -244,7 +244,7 @@ func (cmd *SSHCmd) startTunnel(ctx context.Context, devPodConfig *config.Config,
 	defer writer.Close()
 
 	log.Debugf("Run outer container tunnel")
-	command := fmt.Sprintf("'%s' helper ssh-server --track-activity --stdio --workdir '%s'", agent.ContainerDevPodHelperLocation, filepath.Join("workspaces", workspaceName))
+	command := fmt.Sprintf("'%s' helper ssh-server --track-activity --stdio --workdir '%s'", agent.ContainerDevPodHelperLocation, filepath.Join("/workspaces", workspaceName))
 	if cmd.Debug {
 		command += " --debug"
 	}

--- a/pkg/ssh/server/ssh.go
+++ b/pkg/ssh/server/ssh.go
@@ -333,7 +333,7 @@ func (s *Server) getCommand(sess ssh.Session, isPty bool) *exec.Cmd {
 	// check if requested workdir exists
 	if s.workdir != "" {
 		if _, err := os.Stat(s.workdir); err != nil {
-			workdir = s.workdir;
+			workdir = s.workdir
 		}
 	}
 	// fall back to home directory

--- a/pkg/ssh/server/ssh.go
+++ b/pkg/ssh/server/ssh.go
@@ -332,14 +332,14 @@ func (s *Server) getCommand(sess ssh.Session, isPty bool) *exec.Cmd {
 	var workdir string
 	// check if requested workdir exists
 	if s.workdir != "" {
-		if _, err := os.Stat(s.workdir); err != nil {
+		if _, err := os.Stat(s.workdir); err == nil {
 			workdir = s.workdir
 		}
 	}
 	// fall back to home directory
 	if workdir == "" {
 		home, _ := command.GetHome(user)
-		if _, err := os.Stat(home); err != nil {
+		if _, err := os.Stat(home); err == nil {
 			workdir = home
 		}
 	}

--- a/pkg/ssh/server/ssh.go
+++ b/pkg/ssh/server/ssh.go
@@ -24,7 +24,7 @@ import (
 
 var DefaultPort = 8022
 
-func NewServer(addr string, hostKey []byte, keys []ssh.PublicKey, log log.Logger) (*Server, error) {
+func NewServer(addr string, hostKey []byte, keys []ssh.PublicKey, workdir string, log log.Logger) (*Server, error) {
 	shell, err := getShell()
 	if err != nil {
 		return nil, err
@@ -38,6 +38,7 @@ func NewServer(addr string, hostKey []byte, keys []ssh.PublicKey, log log.Logger
 	forwardHandler := &ssh.ForwardedTCPHandler{}
 	server := &Server{
 		shell:       shell,
+		workdir:     workdir,
 		log:         log,
 		currentUser: currentUser.Username,
 		sshServer: ssh.Server{
@@ -93,6 +94,7 @@ func NewServer(addr string, hostKey []byte, keys []ssh.PublicKey, log log.Logger
 type Server struct {
 	currentUser string
 	shell       []string
+	workdir     string
 	sshServer   ssh.Server
 	log         log.Logger
 }
@@ -328,10 +330,13 @@ func (s *Server) getCommand(sess ssh.Session, isPty bool) *exec.Cmd {
 	}
 
 	// switch default directory
-	home, _ := command.GetHome(user)
-	_, err := os.Stat(home)
+	workdir := s.workdir
+	if workdir == "" {
+		workdir, _ = command.GetHome(user)
+	}
+	_, err := os.Stat(workdir)
 	if err == nil {
-		cmd.Dir = home
+		cmd.Dir = workdir
 	}
 	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Env = append(cmd.Env, sess.Environ()...)


### PR DESCRIPTION
Fixes #730

I didn't go as far as adding a `--workdir` argument to `devpod ssh` as suggested in https://github.com/loft-sh/devpod/issues/730#issuecomment-1759072845 because it isn't strictly necessary.

Looking forward to feedback.

Should this be tested in any way?