### PR TITLE
fix: improve error logging across commands and postcreate commands

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -284,13 +284,15 @@ func dockerlessBuild(
 
 	// write output to log
 	writer := log.Writer(logrus.InfoLevel, false)
+	errwriter := log.Writer(logrus.ErrorLevel, false)
 	defer writer.Close()
+	defer errwriter.Close()
 
 	// start building
 	log.Infof("Start dockerless building %s %s", "/.dockerless/dockerless", strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, "/.dockerless/dockerless", args...)
 	cmd.Stdout = writer
-	cmd.Stderr = writer
+	cmd.Stderr = errwriter
 	cmd.Env = os.Environ()
 	err = cmd.Run()
 	if err != nil {

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -345,7 +345,9 @@ func CloneRepository(ctx context.Context, local bool, workspaceDir string, sourc
 	}()
 
 	writer := log.Writer(logrus.InfoLevel, false)
+	errwriter := log.Writer(logrus.ErrorLevel, false)
 	defer writer.Close()
+	defer errwriter.Close()
 
 	// check if command exists
 	if !command.Exists("git") {
@@ -363,14 +365,14 @@ func CloneRepository(ctx context.Context, local bool, workspaceDir string, sourc
 			log.Infof("Git command is missing, try to install git with apt...")
 			cmd := exec.Command("apt", "update")
 			cmd.Stdout = writer
-			cmd.Stderr = writer
+			cmd.Stderr = errwriter
 			err := cmd.Run()
 			if err != nil {
 				return errors.Wrap(err, "run apt update")
 			}
 			cmd = exec.Command("apt", "-y", "install", "git")
 			cmd.Stdout = writer
-			cmd.Stderr = writer
+			cmd.Stderr = errwriter
 			err = cmd.Run()
 			if err != nil {
 				return errors.Wrap(err, "run apt install git -y")
@@ -379,14 +381,14 @@ func CloneRepository(ctx context.Context, local bool, workspaceDir string, sourc
 			log.Infof("Git command is missing, try to install git with apk...")
 			cmd := exec.Command("apk", "update")
 			cmd.Stdout = writer
-			cmd.Stderr = writer
+			cmd.Stderr = errwriter
 			err := cmd.Run()
 			if err != nil {
 				return errors.Wrap(err, "run apk update")
 			}
 			cmd = exec.Command("apk", "add", "git")
 			cmd.Stdout = writer
-			cmd.Stderr = writer
+			cmd.Stderr = errwriter
 			err = cmd.Run()
 			if err != nil {
 				return errors.Wrap(err, "run apk add git")

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -269,7 +269,7 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			framework.ExpectError(err, "expected error")
 			framework.ExpectNoError(verifyLogStream(strings.NewReader(stdout)))
 			framework.ExpectNoError(verifyLogStream(strings.NewReader(stderr)))
-			framework.ExpectNoError(findMessage(strings.NewReader(stdout), "exec: \"abc\": executable file not found in $PATH"))
+			framework.ExpectNoError(findMessage(strings.NewReader(stderr), "exec: \"abc\": executable file not found in $PATH"))
 		}, ginkgo.SpecTimeout(60*time.Second))
 	})
 
@@ -373,7 +373,6 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 				err = f.DevPodUp(ctx, tempDir)
 				framework.ExpectNoError(err)
 			}, ginkgo.SpecTimeout(60*time.Second))
-
 		})
 
 		ginkgo.Context("with docker", ginkgo.Ordered, func() {

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -269,7 +269,7 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			framework.ExpectError(err, "expected error")
 			framework.ExpectNoError(verifyLogStream(strings.NewReader(stdout)))
 			framework.ExpectNoError(verifyLogStream(strings.NewReader(stderr)))
-			framework.ExpectNoError(findMessage(strings.NewReader(stderr), "exec: \"abc\": executable file not found in $PATH"))
+			framework.ExpectNoError(findMessage(strings.NewReader(stdout), "exec: \"abc\": executable file not found in $PATH"))
 		}, ginkgo.SpecTimeout(60*time.Second))
 	})
 

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -267,11 +267,13 @@ func runInitializeCommand(
 		// run the command
 		log.Infof("Running initializeCommand from devcontainer.json: '%s'", strings.Join(args, " "))
 		writer := log.Writer(logrus.InfoLevel, false)
+		errwriter := log.Writer(logrus.ErrorLevel, false)
 		defer writer.Close()
+		defer errwriter.Close()
 
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Stdout = writer
-		cmd.Stderr = writer
+		cmd.Stderr = errwriter
 		cmd.Dir = workspaceFolder
 		err := cmd.Run()
 		if err != nil {

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -332,7 +332,7 @@ func runPostCreateCommand(commands []types.LifecycleHook, user, dir string, remo
 			log.Debugf("Executing command %s: %s...", k, cmd.Args)
 			err := cmd.Run()
 			if err != nil {
-				log.Debugf("Failed running postcreate command %s: %v", cmd.Args, err)
+				log.Debugf("Failed running postCreateCommand lifecycle script %s: %v", cmd.Args, err)
 				return fmt.Errorf("failed to run: %s, error: %w", strings.Join(c, " "), err)
 			}
 			log.Donef("Successfully ran command %s: %s", k, strings.Join(c, " "))

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -236,7 +237,7 @@ func PostCreateCommands(setupInfo *config.Result, log log.Logger) error {
 		return err
 	}
 
-	//TODO: rerun when contents changed
+	// TODO: rerun when contents changed
 	err = runPostCreateCommand(mergedConfig.UpdateContentCommands, remoteUser, setupInfo.SubstitutionContext.ContainerWorkspaceFolder, setupInfo.MergedConfig.RemoteEnv, "updateContentCommands", setupInfo.ContainerDetails.Created, log)
 	if err != nil {
 		return err
@@ -303,7 +304,9 @@ func runPostCreateCommand(commands []types.LifecycleHook, user, dir string, remo
 	}
 
 	writer := log.Writer(logrus.InfoLevel, false)
+	errwriter := log.Writer(logrus.ErrorLevel, false)
 	defer writer.Close()
+	defer errwriter.Close()
 
 	for _, cmd := range commands {
 		if len(cmd) == 0 {
@@ -325,11 +328,12 @@ func runPostCreateCommand(commands []types.LifecycleHook, user, dir string, remo
 			cmd.Env = os.Environ()
 			cmd.Env = append(cmd.Env, remoteEnvArr...)
 			cmd.Stdout = writer
-			cmd.Stderr = writer
+			cmd.Stderr = errwriter
+			log.Debugf("Executing command %s: %s...", k, cmd.Args)
 			err := cmd.Run()
 			if err != nil {
-				log.Errorf("Failed running command %s: %v", k, err)
-				return err
+				log.Debugf("Failed running postcreate command %s: %v", cmd.Args, err)
+				return fmt.Errorf("failed to run: %s, error: %w", strings.Join(c, " "), err)
 			}
 			log.Donef("Successfully ran command %s: %s", k, strings.Join(c, " "))
 		}

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -103,7 +103,7 @@ func ExecuteCommand(ctx context.Context, client client2.WorkspaceClient, agentIn
 			}
 		}
 
-		writer := log.Writer(logrus.ErrorLevel, false)
+		writer := log.Writer(logrus.InfoLevel, false)
 		defer writer.Close()
 
 		err = devssh.Run(ctx, sshClient, command, gRPCConnStdinReader, gRPCConnStdoutWriter, writer)

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -103,7 +103,7 @@ func ExecuteCommand(ctx context.Context, client client2.WorkspaceClient, agentIn
 			}
 		}
 
-		writer := log.Writer(logrus.InfoLevel, false)
+		writer := log.Writer(logrus.ErrorLevel, false)
 		defer writer.Close()
 
 		err = devssh.Run(ctx, sshClient, command, gRPCConnStdinReader, gRPCConnStdoutWriter, writer)

--- a/pkg/ide/vscode/vscode.go
+++ b/pkg/ide/vscode/vscode.go
@@ -91,7 +91,9 @@ func (o *VsCodeServer) InstallExtensions() error {
 
 	// start log writer
 	writer := o.log.Writer(logrus.InfoLevel, false)
+	errwriter := o.log.Writer(logrus.ErrorLevel, false)
 	defer writer.Close()
+	defer errwriter.Close()
 
 	// download extensions
 	for _, extension := range o.extensions {
@@ -105,7 +107,7 @@ func (o *VsCodeServer) InstallExtensions() error {
 		}
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Stdout = writer
-		cmd.Stderr = writer
+		cmd.Stderr = errwriter
 		err := cmd.Run()
 		if err != nil {
 			o.log.Info("Failed installing extension " + extension)


### PR DESCRIPTION
Generally improve STDERR logging by using the error level instead of info level
Add more messages to postcreate command execution

Giving now a more clear and first-glanceable output

![image](https://github.com/loft-sh/devpod/assets/598882/7c0dc475-82b7-4eeb-9bee-0ebe489d8774)

Fix #775 
Resolves ENG-2298