### PR TITLE
chore: update IDE versions

### DIFF
--- a/pkg/ide/jetbrains/clion.go
+++ b/pkg/ide/jetbrains/clion.go
@@ -6,14 +6,16 @@ import (
 	"github.com/loft-sh/log"
 )
 
-const CLionDownloadAmd64Template = "https://download.jetbrains.com/cpp/CLion-%s.tar.gz"
-const CLionDownloadArm64Template = "https://download.jetbrains.com/cpp/CLion-%s-aarch64.tar.gz"
+const (
+	CLionDownloadAmd64Template = "https://download.jetbrains.com/cpp/CLion-%s.tar.gz"
+	CLionDownloadArm64Template = "https://download.jetbrains.com/cpp/CLion-%s-aarch64.tar.gz"
+)
 
 var CLionOptions = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the binary",
-		Default:     "2023.1.2",
+		Default:     "2023.2.2",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,

--- a/pkg/ide/jetbrains/goland.go
+++ b/pkg/ide/jetbrains/goland.go
@@ -6,14 +6,16 @@ import (
 	"github.com/loft-sh/log"
 )
 
-const GolandDownloadAmd64Template = "https://download.jetbrains.com/go/goland-%s.tar.gz"
-const GolandDownloadArm64Template = "https://download.jetbrains.com/go/goland-%s-aarch64.tar.gz"
+const (
+	GolandDownloadAmd64Template = "https://download.jetbrains.com/go/goland-%s.tar.gz"
+	GolandDownloadArm64Template = "https://download.jetbrains.com/go/goland-%s-aarch64.tar.gz"
+)
 
 var GolandOptions = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the binary",
-		Default:     "2023.1.1",
+		Default:     "2023.2.4",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,

--- a/pkg/ide/jetbrains/intellij.go
+++ b/pkg/ide/jetbrains/intellij.go
@@ -6,14 +6,16 @@ import (
 	"github.com/loft-sh/log"
 )
 
-const IntellijDownloadAmd64Template = "https://download.jetbrains.com/idea/ideaIU-%s.tar.gz"
-const IntellijDownloadArm64Template = "https://download.jetbrains.com/idea/ideaIU-%s-aarch64.tar.gz"
+const (
+	IntellijDownloadAmd64Template = "https://download.jetbrains.com/idea/ideaIU-%s.tar.gz"
+	IntellijDownloadArm64Template = "https://download.jetbrains.com/idea/ideaIU-%s-aarch64.tar.gz"
+)
 
 var IntellijOptions = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the binary",
-		Default:     "2023.1.1",
+		Default:     "2023.2.4",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,

--- a/pkg/ide/jetbrains/phpstorm.go
+++ b/pkg/ide/jetbrains/phpstorm.go
@@ -6,14 +6,16 @@ import (
 	"github.com/loft-sh/log"
 )
 
-const PhpStormDownloadAmd64Template = "https://download.jetbrains.com/webide/PhpStorm-%s.tar.gz"
-const PhpStormDownloadArm64Template = "https://download.jetbrains.com/webide/PhpStorm-%s-aarch64.tar.gz"
+const (
+	PhpStormDownloadAmd64Template = "https://download.jetbrains.com/webide/PhpStorm-%s.tar.gz"
+	PhpStormDownloadArm64Template = "https://download.jetbrains.com/webide/PhpStorm-%s-aarch64.tar.gz"
+)
 
 var PhpStormOptions = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the binary",
-		Default:     "2023.1.3",
+		Default:     "2023.2.3",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,

--- a/pkg/ide/jetbrains/pycharm.go
+++ b/pkg/ide/jetbrains/pycharm.go
@@ -6,14 +6,16 @@ import (
 	"github.com/loft-sh/log"
 )
 
-const PycharmDownloadAmd64Template = "https://download.jetbrains.com/python/pycharm-professional-%s.tar.gz"
-const PycharmDownloadArm64Template = "https://download.jetbrains.com/python/pycharm-professional-%s-aarch64.tar.gz"
+const (
+	PycharmDownloadAmd64Template = "https://download.jetbrains.com/python/pycharm-professional-%s.tar.gz"
+	PycharmDownloadArm64Template = "https://download.jetbrains.com/python/pycharm-professional-%s-aarch64.tar.gz"
+)
 
 var PyCharmOptions = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the binary",
-		Default:     "2023.1.1",
+		Default:     "2023.2.3",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,

--- a/pkg/ide/jetbrains/rider.go
+++ b/pkg/ide/jetbrains/rider.go
@@ -6,14 +6,16 @@ import (
 	"github.com/loft-sh/log"
 )
 
-const RiderDownloadAmd64Template = "https://download.jetbrains.com/rider/JetBrains.Rider-%s.tar.gz"
-const RiderDownloadArm64Template = "https://download.jetbrains.com/rider/JetBrains.Rider-%s-aarch64.tar.gz"
+const (
+	RiderDownloadAmd64Template = "https://download.jetbrains.com/rider/JetBrains.Rider-%s.tar.gz"
+	RiderDownloadArm64Template = "https://download.jetbrains.com/rider/JetBrains.Rider-%s-aarch64.tar.gz"
+)
 
 var RiderOptions = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the binary",
-		Default:     "2023.1.1",
+		Default:     "2023.2.3",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,

--- a/pkg/ide/jetbrains/rubymine.go
+++ b/pkg/ide/jetbrains/rubymine.go
@@ -6,14 +6,16 @@ import (
 	"github.com/loft-sh/log"
 )
 
-const RubyMineDownloadAmd64Template = "https://download.jetbrains.com/ruby/RubyMine-%s.tar.gz"
-const RubyMineDownloadArm64Template = "https://download.jetbrains.com/ruby/RubyMine-%s-aarch64.tar.gz"
+const (
+	RubyMineDownloadAmd64Template = "https://download.jetbrains.com/ruby/RubyMine-%s.tar.gz"
+	RubyMineDownloadArm64Template = "https://download.jetbrains.com/ruby/RubyMine-%s-aarch64.tar.gz"
+)
 
 var RubyMineOptions = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the binary",
-		Default:     "2023.1.1",
+		Default:     "2023.2.4",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,

--- a/pkg/ide/jetbrains/webstorm.go
+++ b/pkg/ide/jetbrains/webstorm.go
@@ -6,14 +6,16 @@ import (
 	"github.com/loft-sh/log"
 )
 
-const WebStormDownloadAmd64Template = "https://download.jetbrains.com/webstorm/WebStorm-%s.tar.gz"
-const WebStormDownloadArm64Template = "https://download.jetbrains.com/webstorm/WebStorm-%s-aarch64.tar.gz"
+const (
+	WebStormDownloadAmd64Template = "https://download.jetbrains.com/webstorm/WebStorm-%s.tar.gz"
+	WebStormDownloadArm64Template = "https://download.jetbrains.com/webstorm/WebStorm-%s-aarch64.tar.gz"
+)
 
 var WebStormOptions = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the binary",
-		Default:     "2023.1.1",
+		Default:     "2023.2.4",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,

--- a/pkg/ide/openvscode/openvscode.go
+++ b/pkg/ide/openvscode/openvscode.go
@@ -22,8 +22,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const DownloadAmd64Template = "https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-%s/openvscode-server-%s-linux-x64.tar.gz"
-const DownloadArm64Template = "https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-%s/openvscode-server-%s-linux-arm64.tar.gz"
+const (
+	DownloadAmd64Template = "https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-%s/openvscode-server-%s-linux-x64.tar.gz"
+	DownloadArm64Template = "https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-%s/openvscode-server-%s-linux-arm64.tar.gz"
+)
 
 const (
 	ForwardPortsOption  = "FORWARD_PORTS"
@@ -52,7 +54,7 @@ var Options = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the open vscode binary",
-		Default:     "v1.79.2",
+		Default:     "v1.83.0",
 	},
 	OpenOption: {
 		Name:        OpenOption,


### PR DESCRIPTION
Update IDE versions

OpenVSCode -> 1.83.0
Clion -> 2023.2.2
Golang -> 2023.2.4
Intellij -> 2023.2.4
PhpStorm -> 2023.2.3
PyCharm -> 2023.2.3
Rider -> 2023.2.3
RubyMine -> 2023.2.4

Resolves ENG-2339