### PR TITLE
fix: revert regression introduced in 0a40554 for WSL systems

### DIFF
--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -304,7 +302,7 @@ func (d *dockerDriver) RunDockerDevContainer(
 	writer := d.Log.Writer(logrus.InfoLevel, false)
 	defer writer.Close()
 
-	err := d.Docker.RunWithDir(ctx, path.Dir(filepath.ToSlash(parsedConfig.Origin)), args, nil, writer, writer)
+	err := d.Docker.Run(ctx, args, nil, writer, writer)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resolve regression where running docker commands with "RunWithDir" breaks compatibility with WSL filepaths on Windows

Fix #644 
Resolve ENG-1965