### PR TITLE
added opentelekomcloud as a community provider

### DIFF
--- a/community.yaml
+++ b/community.yaml
@@ -8,3 +8,4 @@ providers:
   - repository: https://github.com/flowswiss/devpod-provider-flow
   - repository: https://github.com/navaneeth-dev/devpod-provider-vultr
   - repository: https://github.com/minhio/devpod-provider-multipass
+  - repository: https://github.com/akyriako/devpod-provider-opentelekomcloud

--- a/docs/pages/managing-providers/add-provider.mdx
+++ b/docs/pages/managing-providers/add-provider.mdx
@@ -233,6 +233,7 @@ The community maintains providers for additional services.
 - [Equinix (dirien/devpod-provider-equinix)](https://github.com/dirien/devpod-provider-equinix)
 - [Exoscale (dirien/devpod-provider-exoscale)](https://github.com/dirien/devpod-provider-exoscale)
 - [Multipass (minhio/devpod-provider-multipass)](https://github.com/minhio/devpod-provider-multipass)
+- [Open Telekom Cloud (akyriako/devpod-provider-opentelekomcloud)](https://github.com/akyriako/devpod-provider-opentelekomcloud)
 
 These providers can be installed with the DevPod CLI in the following form:
 ```


### PR DESCRIPTION
Added support for Open Telekom Cloud, the OpenStack-based public cloud offering of the German leading IT services provider T-Systems International GmbH. 

That is a community project, not an officially supported one by T-Systems International GmbH.