### PR TITLE
Fix/inactivity timeout

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -104,3 +104,4 @@ jobs:
       run: |
         Remove-Item -Recurse C:\Users\loft-user\.devpod\
         sh -c "docker ps -a | cut -d' ' -f1 | tail -n+2 | xargs docker rm -f || :"
+        docker system prune -a -f

--- a/.github/workflows/e2e-win-full-tests.yaml
+++ b/.github/workflows/e2e-win-full-tests.yaml
@@ -51,3 +51,4 @@ jobs:
       run: |
         Remove-Item -Recurse C:\Users\loft-user\.devpod\
         sh -c "docker ps -a | cut -d' ' -f1 | tail -n+2 | xargs docker rm -f || :"
+        docker system prune -a -f

--- a/cmd/agent/container/daemon.go
+++ b/cmd/agent/container/daemon.go
@@ -43,10 +43,12 @@ func (cmd *DaemonCmd) Run(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	err = os.WriteFile(agent.ContainerActivityFile, nil, 0777)
+	err = os.WriteFile(agent.ContainerActivityFile, nil, 0o777)
 	if err != nil {
 		return err
 	}
+
+	_ = os.Chmod(agent.ContainerActivityFile, 0o777)
 
 	// query the activity file
 	for {

--- a/cmd/agent/container/daemon.go
+++ b/cmd/agent/container/daemon.go
@@ -48,7 +48,10 @@ func (cmd *DaemonCmd) Run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	_ = os.Chmod(agent.ContainerActivityFile, 0o777)
+	err = os.Chmod(agent.ContainerActivityFile, 0o777)
+	if err != nil {
+		return err
+	}
 
 	// query the activity file
 	for {

--- a/cmd/helper/fleet_helper.go
+++ b/cmd/helper/fleet_helper.go
@@ -1,0 +1,68 @@
+package helper
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/loft-sh/devpod/cmd/flags"
+	"github.com/loft-sh/devpod/pkg/agent"
+	"github.com/spf13/cobra"
+)
+
+// FleetServerCmd holds the fleet server cmd flags
+type FleetServerCmd struct {
+	*flags.GlobalFlags
+
+	WorkspaceID string
+}
+
+// NewFleetServerCmd creates a new fleet command
+func NewFleetServerCmd(flags *flags.GlobalFlags) *cobra.Command {
+	cmd := &FleetServerCmd{
+		GlobalFlags: flags,
+	}
+	fleetCmd := &cobra.Command{
+		Use:   "fleet-server",
+		Short: "Monitor fleet server activity",
+		Args:  cobra.NoArgs,
+		RunE:  cmd.Run,
+	}
+
+	fleetCmd.Flags().StringVar(&cmd.WorkspaceID, "workspaceid", "", "Fleet WorkspaceID to monitor")
+	return fleetCmd
+}
+
+// Run runs the command logic
+func (cmd *FleetServerCmd) Run(_ *cobra.Command, _ []string) error {
+	logFile := filepath.Join(os.Getenv("HOME"), ".cache/JetBrains/Fleet/log/fleet.log")
+	firstConnection := regexp.MustCompile(`.*Received authorization request.*`)
+	connStatus := regexp.MustCompile(`.*Notify.*`)
+
+	for {
+		time.Sleep(time.Second * 10)
+
+		log, err := os.ReadFile(logFile)
+		if err != nil {
+			continue
+		}
+
+		// check if we had at least one fleet client connection, before
+		// this point, we don't check for connected/disconnected strings
+		initialized := firstConnection.FindStringSubmatch(string(log))
+		if len(initialized) == 0 {
+			continue
+		}
+
+		connString := connStatus.FindAllStringSubmatch(string(log), -1)
+
+		// if ouf last occurrence of notify if "Notify ID connected"
+		// we have an active session, so let's keep alive
+		if strings.Contains(connString[len(connString)-1][0], "is connected") {
+			file, _ := os.Create(agent.ContainerActivityFile)
+			file.Close()
+		}
+	}
+}

--- a/cmd/helper/helper.go
+++ b/cmd/helper/helper.go
@@ -30,5 +30,6 @@ func NewHelperCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	helperCmd.AddCommand(NewCheckProviderUpdateCmd(globalFlags))
 	helperCmd.AddCommand(NewSSHClientCmd())
 	helperCmd.AddCommand(NewShellCmd())
+	helperCmd.AddCommand(NewFleetServerCmd(globalFlags))
 	return helperCmd
 }

--- a/cmd/helper/ssh_server.go
+++ b/cmd/helper/ssh_server.go
@@ -100,19 +100,19 @@ func (cmd *SSHServerCmd) Run(_ *cobra.Command, _ []string) error {
 			go func() {
 				_, err = os.Stat(agent.ContainerActivityFile)
 				if err != nil {
-					err = os.WriteFile(agent.ContainerActivityFile, nil, 0777)
+					err = os.WriteFile(agent.ContainerActivityFile, nil, 0o777)
 					if err != nil {
 						fmt.Fprintf(os.Stderr, "Error writing file: %v\n", err)
 						return
 					}
 
-					_ = os.Chmod(agent.ContainerActivityFile, 0777)
+					_ = os.Chmod(agent.ContainerActivityFile, 0o777)
 				}
 
 				for {
 					time.Sleep(time.Second * 10)
-					now := time.Now()
-					_ = os.Chtimes(agent.ContainerActivityFile, now, now)
+					file, _ := os.Create(agent.ContainerActivityFile)
+					file.Close()
 				}
 			}()
 		}

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -251,8 +251,18 @@ func (d *dockerDriver) RunDockerDevContainer(
 	}
 
 	// mounts
+	tmpfsMount := true
 	for _, mount := range options.Mounts {
+		// skip tmpfs mount on /tmp if devcontainer specifies another mount option
+		if strings.Contains(mount.String(), "/tmp") {
+			tmpfsMount = false
+		}
 		args = append(args, "--mount", mount.String())
+	}
+
+	// ensure /tmp is a tmpfs like on regular linux distros
+	if tmpfsMount {
+		args = append(args, "--mount", "type=tmpfs,destination=/tmp")
 	}
 
 	// add ide mounts

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -254,7 +254,8 @@ func (d *dockerDriver) RunDockerDevContainer(
 	tmpfsMount := true
 	for _, mount := range options.Mounts {
 		// skip tmpfs mount on /tmp if devcontainer specifies another mount option
-		if strings.Contains(mount.String(), "/tmp") {
+		if strings.Contains(mount.String(), "destination=/tmp") ||
+			strings.Contains(mount.String(), "target=/tmp") {
 			tmpfsMount = false
 		}
 		args = append(args, "--mount", mount.String())


### PR DESCRIPTION
Fix #776 
Fix #795 
Resolves ENG-2346
Resolves ENG-2299

This PR will fix a bug in `ssh_helper`'s `track-activity` that was not updating correctly the activity file in some situations,
also we standardize the `/tmp` in tmpfs as in many other linux distributions

This PR will also introduce a little fleet-server helper, in order to keep track of the fleet's connection activities and update the devpod's activity file accordingly, thus making it respect the inactivity timeout