### PR TITLE
feat: start workspace in a subpath

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -103,5 +103,5 @@ jobs:
       if: ${{ always() }}
       run: |
         Remove-Item -Recurse C:\Users\loft-user\.devpod\
-        sh -c "docker ps -a | cut -d' ' -f1 | tail -n+2 | xargs docker rm -f || :"
-        docker system prune -a -f
+        sh -c "docker ps -q -a | xargs docker rm -f || :"
+        sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep devpod | cut -d',' -f2 | xargs docker rmi -f || :"

--- a/.github/workflows/e2e-win-full-tests.yaml
+++ b/.github/workflows/e2e-win-full-tests.yaml
@@ -50,5 +50,5 @@ jobs:
       if: ${{ always() }}
       run: |
         Remove-Item -Recurse C:\Users\loft-user\.devpod\
-        sh -c "docker ps -a | cut -d' ' -f1 | tail -n+2 | xargs docker rm -f || :"
-        docker system prune -a -f
+        sh -c "docker ps -q -a | xargs docker rm -f || :"
+        sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep devpod | cut -d',' -f2 | xargs docker rmi -f || :"

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -459,7 +459,7 @@ func CloneRepository(ctx context.Context, local bool, workspaceDir string, sourc
 	}
 
 	// run git command
-	gitInfo := git.NewGitInfo(source.GitRepository, source.GitBranch, source.GitCommit, source.GitPRReference)
+	gitInfo := git.NewGitInfo(source.GitRepository, source.GitBranch, source.GitCommit, source.GitPRReference, source.GitSubPath)
 	err := git.CloneRepository(ctx, gitInfo, workspaceDir, helper, false, writer, log)
 	if err != nil {
 		return errors.Wrap(err, "clone repository")

--- a/cmd/helper/get_workspace_config.go
+++ b/cmd/helper/get_workspace_config.go
@@ -146,12 +146,12 @@ func findDevcontainerFiles(ctx context.Context, rawSource, tmpDirPath string, ma
 	}
 
 	// git repo
-	gitRepository, gitPRReference, gitBranch, gitCommit := git.NormalizeRepository(rawSource)
+	gitRepository, gitPRReference, gitBranch, gitCommit, gitSubDir := git.NormalizeRepository(rawSource)
 	if strings.HasSuffix(rawSource, ".git") || git.PingRepository(gitRepository) {
 		log.Debug("Git repository detected")
 		result.IsGitRepository = true
 
-		gitInfo := git.NewGitInfo(gitRepository, gitBranch, gitCommit, gitPRReference)
+		gitInfo := git.NewGitInfo(gitRepository, gitBranch, gitCommit, gitPRReference, gitSubDir)
 		log.Debugf("Cloning git repository into %s", tmpDirPath)
 		err := git.CloneRepository(ctx, gitInfo, tmpDirPath, "", true, log.Writer(logrus.DebugLevel, false), log)
 		if err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -186,7 +186,6 @@ func (cmd *UpCmd) Run(
 	if client.WorkspaceConfig().Source.GitSubPath != "" {
 		result.SubstitutionContext.ContainerWorkspaceFolder = filepath.Join(result.SubstitutionContext.ContainerWorkspaceFolder, client.WorkspaceConfig().Source.GitSubPath)
 		workdir = result.SubstitutionContext.ContainerWorkspaceFolder
-
 	}
 
 	// configure container ssh

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -183,6 +183,12 @@ func (cmd *UpCmd) Run(
 		workdir = result.SubstitutionContext.ContainerWorkspaceFolder
 	}
 
+	if client.WorkspaceConfig().Source.GitSubPath != "" {
+		result.SubstitutionContext.ContainerWorkspaceFolder = filepath.Join(result.SubstitutionContext.ContainerWorkspaceFolder, client.WorkspaceConfig().Source.GitSubPath)
+		workdir = result.SubstitutionContext.ContainerWorkspaceFolder
+
+	}
+
 	// configure container ssh
 	if cmd.ConfigureSSH {
 		err = configureSSH(devPodConfig, client, cmd.SSHConfigPath, user, workdir,

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -139,8 +139,6 @@ func NewUpCmd(flags *flags.GlobalFlags) *cobra.Command {
 	upCmd.Flags().StringVar(&cmd.IDE, "ide", "", "The IDE to open the workspace in. If empty will use vscode locally or in browser")
 	upCmd.Flags().BoolVar(&cmd.OpenIDE, "open-ide", true, "If this is false and an IDE is configured, DevPod will only install the IDE server backend, but not open it")
 
-	upCmd.Flags().StringVar(&cmd.WorkspaceSubPath, "subpath", "", "Use specific subpath in project instead of root of workspace")
-
 	upCmd.Flags().BoolVar(&cmd.DisableDaemon, "disable-daemon", false, "If enabled, will not install a daemon into the target machine to track activity")
 	upCmd.Flags().StringVar(&cmd.Source, "source", "", "Optional source for the workspace. E.g. git:https://github.com/my-org/my-repo")
 	upCmd.Flags().BoolVar(&cmd.Proxy, "proxy", false, "If true will forward agent requests to stdio")
@@ -176,11 +174,6 @@ func (cmd *UpCmd) Run(
 	var workdir string
 	if result.MergedConfig != nil && result.MergedConfig.WorkspaceFolder != "" {
 		workdir = result.MergedConfig.WorkspaceFolder
-	}
-
-	if cmd.WorkspaceSubPath != "" {
-		result.SubstitutionContext.ContainerWorkspaceFolder = filepath.Join(result.SubstitutionContext.ContainerWorkspaceFolder, cmd.WorkspaceSubPath)
-		workdir = result.SubstitutionContext.ContainerWorkspaceFolder
 	}
 
 	if client.WorkspaceConfig().Source.GitSubPath != "" {

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -80,6 +80,8 @@ var _ = DevPodDescribe("devpod ssh test suite", func() {
 			err = f.DevPodUp(devpodUpCtx, tempDir, "--gpg-agent-forwarding")
 			framework.ExpectNoError(err)
 
+			time.Sleep(time.Second * 10)
+
 			devpodSSHDeadline := time.Now().Add(20 * time.Second)
 			devpodSSHCtx, cancelSSH := context.WithDeadline(context.Background(), devpodSSHDeadline)
 			defer cancelSSH()

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -277,6 +277,33 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			framework.ExpectNoError(err)
 		})
 
+		ginkgo.It("create workspace in a subpath", func() {
+			const providerName = "test-docker"
+			ctx := context.Background()
+
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+
+			// provider add, use and delete afterwards
+			err := f.DevPodProviderAdd(ctx, "docker", "--name", providerName)
+			framework.ExpectNoError(err)
+			err = f.DevPodProviderUse(ctx, providerName)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() {
+				err = f.DevPodProviderDelete(ctx, providerName)
+				framework.ExpectNoError(err)
+			})
+
+			err = f.DevPodUp(ctx, "https://github.com/loft-sh/examples/@subpath:/devpod/jupyter-notebook-hello-world")
+			framework.ExpectNoError(err)
+
+			out, err := f.DevPodSSH(ctx, "jupyter-notebook-hello-world", "pwd")
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(out, "/workspaces/jupyter-notebook-hello-world\n", "should be subpath")
+
+			err = f.DevPodWorkspaceDelete(ctx, "jupyter-notebook-hello-world")
+			framework.ExpectNoError(err)
+		})
+
 		ginkgo.Context("print error message correctly", func() {
 			ginkgo.It("make sure devpod output is correct and log-output works correctly", func(ctx context.Context) {
 				f := framework.NewDefaultFramework(initialDir + "/bin")

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -186,6 +186,10 @@ func (r *runner) prepare(
 			localWorkspaceFolder = filepath.Join(r.LocalWorkspaceFolder, r.WorkspaceConfig.CLIOptions.WorkspaceSubPath)
 		}
 
+		if r.WorkspaceConfig.Workspace.Source.GitSubPath != "" {
+			localWorkspaceFolder = filepath.Join(r.LocalWorkspaceFolder, r.WorkspaceConfig.Workspace.Source.GitSubPath)
+		}
+
 		// parse the devcontainer json
 		rawParsedConfig, err = config.ParseDevContainerJSON(
 			localWorkspaceFolder,

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -182,9 +182,6 @@ func (r *runner) prepare(
 
 		localWorkspaceFolder := r.LocalWorkspaceFolder
 		// if a subpath is specified, let's move to it
-		if r.WorkspaceConfig.CLIOptions.WorkspaceSubPath != "" {
-			localWorkspaceFolder = filepath.Join(r.LocalWorkspaceFolder, r.WorkspaceConfig.CLIOptions.WorkspaceSubPath)
-		}
 
 		if r.WorkspaceConfig.Workspace.Source.GitSubPath != "" {
 			localWorkspaceFolder = filepath.Join(r.LocalWorkspaceFolder, r.WorkspaceConfig.Workspace.Source.GitSubPath)

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -180,9 +180,15 @@ func (r *runner) prepare(
 	} else {
 		var err error
 
+		localWorkspaceFolder := r.LocalWorkspaceFolder
+		// if a subpath is specified, let's move to it
+		if r.WorkspaceConfig.CLIOptions.WorkspaceSubPath != "" {
+			localWorkspaceFolder = filepath.Join(r.LocalWorkspaceFolder, r.WorkspaceConfig.CLIOptions.WorkspaceSubPath)
+		}
+
 		// parse the devcontainer json
 		rawParsedConfig, err = config.ParseDevContainerJSON(
-			r.LocalWorkspaceFolder,
+			localWorkspaceFolder,
 			r.WorkspaceConfig.Workspace.DevContainerPath,
 		)
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -15,16 +15,16 @@ import (
 )
 
 const (
-	CommitDelimiter       string = "@sha256:"
-	PullRequestReference  string = "pull/([0-9]+)/head"
-	SubPathDelimiter string = "@subpath:"
+	CommitDelimiter      string = "@sha256:"
+	PullRequestReference string = "pull/([0-9]+)/head"
+	SubPathDelimiter     string = "@subpath:"
 )
 
 var (
-	branchRegEx       = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@/]+/?[^@/]+)@([a-zA-Z0-9\./\-\_]+)$`)
-	commitRegEx       = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@]+)` + regexp.QuoteMeta(CommitDelimiter) + `([a-zA-Z0-9]+)$`)
-	prReferenceRegEx  = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@]+)@(` + PullRequestReference + `)$`)
-	subPathRegEx = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@]+)` + regexp.QuoteMeta(SubPathDelimiter) + `([a-zA-Z0-9\./\-\_]+)$`)
+	branchRegEx      = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@/]+/?[^@/]+)@([a-zA-Z0-9\./\-\_]+)$`)
+	commitRegEx      = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@]+)` + regexp.QuoteMeta(CommitDelimiter) + `([a-zA-Z0-9]+)$`)
+	prReferenceRegEx = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@]+)@(` + PullRequestReference + `)$`)
+	subPathRegEx     = regexp.MustCompile(`^([^@]*(?:git@)?[^@/]+/[^@]+)` + regexp.QuoteMeta(SubPathDelimiter) + `([a-zA-Z0-9\./\-\_]+)$`)
 )
 
 func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
@@ -91,20 +91,20 @@ func GetBranchNameForPR(ref string) string {
 }
 
 type GitInfo struct {
-	Repository   string
-	Branch       string
-	Commit       string
-	PR           string
-	SubPath string
+	Repository string
+	Branch     string
+	Commit     string
+	PR         string
+	SubPath    string
 }
 
 func NewGitInfo(repository, branch, commit, pr, subpath string) *GitInfo {
 	return &GitInfo{
-		Repository:   repository,
-		Branch:       branch,
-		Commit:       commit,
-		PR:           pr,
-		SubPath: subpath,
+		Repository: repository,
+		Branch:     branch,
+		Commit:     commit,
+		PR:         pr,
+		SubPath:    subpath,
 	}
 }
 

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -13,6 +13,7 @@ type testCaseNormalizeRepository struct {
 	expectedRepo        string
 	expectedBranch      string
 	expectedCommit      string
+	expectedSubpath     string
 }
 
 type testCaseGetBranchNameForPR struct {
@@ -28,6 +29,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "ssh://git@github.com/loft-sh/devpod.git",
@@ -35,6 +37,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "git@github.com/loft-sh/devpod-without-branch.git",
@@ -42,6 +45,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "https://github.com/loft-sh/devpod.git",
@@ -49,6 +53,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "github.com/loft-sh/devpod.git",
@@ -56,6 +61,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "github.com/loft-sh/devpod.git@test-branch",
@@ -63,6 +69,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "test-branch",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "git@github.com/loft-sh/devpod-with-branch.git@test-branch",
@@ -70,6 +77,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "test-branch",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "git@github.com/loft-sh/devpod-with-branch.git@test_branch",
@@ -77,6 +85,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "test_branch",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "ssh://git@github.com/loft-sh/devpod.git@test_branch",
@@ -84,6 +93,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "test_branch",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "github.com/loft-sh/devpod-without-protocol-with-slash.git@user/branch",
@@ -91,6 +101,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "user/branch",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "git@github.com/loft-sh/devpod-with-slash.git@user/branch",
@@ -98,6 +109,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "user/branch",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "github.com/loft-sh/devpod.git@sha256:905ffb0",
@@ -105,6 +117,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "",
 			expectedCommit:      "905ffb0",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "git@github.com:loft-sh/devpod.git@sha256:905ffb0",
@@ -112,6 +125,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "",
 			expectedBranch:      "",
 			expectedCommit:      "905ffb0",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "github.com/loft-sh/devpod.git@pull/996/head",
@@ -119,6 +133,7 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "pull/996/head",
 			expectedBranch:      "",
 			expectedCommit:      "",
+			expectedSubpath:     "",
 		},
 		{
 			in:                  "git@github.com:loft-sh/devpod.git@pull/996/head",
@@ -126,15 +141,25 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedPRReference: "pull/996/head",
 			expectedBranch:      "",
 			expectedCommit:      "",
+			expectedSubpath:     "",
+		},
+		{
+			in:                  "github.com/loft-sh/devpod-without-protocol-with-slash.git@subpath:/test/path",
+			expectedRepo:        "https://github.com/loft-sh/devpod-without-protocol-with-slash.git",
+			expectedPRReference: "",
+			expectedBranch:      "",
+			expectedCommit:      "",
+			expectedSubpath:     "/test/path",
 		},
 	}
 
 	for _, testCase := range testCases {
-		outRepo, outPRReference, outBranch, outCommit := NormalizeRepository(testCase.in)
+		outRepo, outPRReference, outBranch, outCommit, outSubpath := NormalizeRepository(testCase.in)
 		assert.Check(t, cmp.Equal(testCase.expectedRepo, outRepo))
 		assert.Check(t, cmp.Equal(testCase.expectedPRReference, outPRReference))
 		assert.Check(t, cmp.Equal(testCase.expectedBranch, outBranch))
 		assert.Check(t, cmp.Equal(testCase.expectedCommit, outCommit))
+		assert.Check(t, cmp.Equal(testCase.expectedSubpath, outSubpath))
 	}
 }
 

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -174,6 +174,8 @@ type CLIOptions struct {
 	DisableDaemon        bool     `json:"disableDaemon,omitempty"`
 	DaemonInterval       string   `json:"daemonInterval,omitempty"`
 
+	WorkspaceSubPath string `json:"workspacesubpath,omitempty"`
+
 	// build options
 	Repository string   `json:"repository,omitempty"`
 	SkipPush   bool     `json:"skipPush,omitempty"`

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -174,7 +174,7 @@ type CLIOptions struct {
 	DisableDaemon        bool     `json:"disableDaemon,omitempty"`
 	DaemonInterval       string   `json:"daemonInterval,omitempty"`
 
-	WorkspaceSubPath string `json:"workspacesubpath,omitempty"`
+	WorkspaceSubPath string `json:"workspaceSubPath,omitempty"`
 
 	// build options
 	Repository string   `json:"repository,omitempty"`

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -177,8 +177,6 @@ type CLIOptions struct {
 	DisableDaemon        bool     `json:"disableDaemon,omitempty"`
 	DaemonInterval       string   `json:"daemonInterval,omitempty"`
 
-	WorkspaceSubPath string `json:"workspaceSubPath,omitempty"`
-
 	// build options
 	Repository string   `json:"repository,omitempty"`
 	SkipPush   bool     `json:"skipPush,omitempty"`

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -227,7 +227,7 @@ func ParseWorkspaceSource(source string) *WorkspaceSource {
 			GitPRReference: gitPRReference,
 			GitBranch:      gitBranch,
 			GitCommit:      gitCommit,
-			GitSubPath:      gitSubdir,
+			GitSubPath:     gitSubdir,
 		}
 	} else if strings.HasPrefix(source, WorkspaceSourceLocal) {
 		return &WorkspaceSource{

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -104,6 +104,9 @@ type WorkspaceSource struct {
 	// GitPRReference is the pull request reference to checkout
 	GitPRReference string `json:"gitPRReference,omitempty"`
 
+	// GitSubPath is the subpath in the repo to use
+	GitSubPath string `json:"gitSubDir,omitempty"`
+
 	// LocalFolder is the local folder to use
 	LocalFolder string `json:"localFolder,omitempty"`
 
@@ -218,12 +221,13 @@ func (w WorkspaceSource) String() string {
 
 func ParseWorkspaceSource(source string) *WorkspaceSource {
 	if strings.HasPrefix(source, WorkspaceSourceGit) {
-		gitRepo, gitPRReference, gitBranch, gitCommit := git.NormalizeRepository(strings.TrimPrefix(source, WorkspaceSourceGit))
+		gitRepo, gitPRReference, gitBranch, gitCommit, gitSubdir := git.NormalizeRepository(strings.TrimPrefix(source, WorkspaceSourceGit))
 		return &WorkspaceSource{
 			GitRepository:  gitRepo,
 			GitPRReference: gitPRReference,
 			GitBranch:      gitBranch,
 			GitCommit:      gitCommit,
+			GitSubPath:      gitSubdir,
 		}
 	} else if strings.HasPrefix(source, WorkspaceSourceLocal) {
 		return &WorkspaceSource{

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -458,7 +458,7 @@ func resolve(
 			GitPRReference: gitPRReference,
 			GitBranch:      gitBranch,
 			GitCommit:      gitCommit,
-			GitSubPath:      gitSubdir,
+			GitSubPath:     gitSubdir,
 		}
 		return workspace, nil
 	}
@@ -525,8 +525,10 @@ func getProjectImage(link string) string {
 	return ""
 }
 
-var workspaceIDRegEx1 = regexp.MustCompile(`[^\w\-]`)
-var workspaceIDRegEx2 = regexp.MustCompile(`[^0-9a-z\-]+`)
+var (
+	workspaceIDRegEx1 = regexp.MustCompile(`[^\w\-]`)
+	workspaceIDRegEx2 = regexp.MustCompile(`[^0-9a-z\-]+`)
+)
 
 func ToID(str string) string {
 	str = strings.ToLower(filepath.ToSlash(str))

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -450,7 +450,7 @@ func resolve(
 	}
 
 	// is git?
-	gitRepository, gitPRReference, gitBranch, gitCommit := git.NormalizeRepository(name)
+	gitRepository, gitPRReference, gitBranch, gitCommit, gitSubdir := git.NormalizeRepository(name)
 	if strings.HasSuffix(name, ".git") || git.PingRepository(gitRepository) {
 		workspace.Picture = getProjectImage(name)
 		workspace.Source = provider2.WorkspaceSource{
@@ -458,6 +458,7 @@ func resolve(
 			GitPRReference: gitPRReference,
 			GitBranch:      gitBranch,
 			GitCommit:      gitCommit,
+			GitSubPath:      gitSubdir,
 		}
 		return workspace, nil
 	}


### PR DESCRIPTION
Initial draft to support specifying a subpath where to start a workspace

When specified the subpath will be used as:

- default workdir via ssh
- default workspace for IDEs
- default path where to search for devcontainer.json

Full project will anyway be cloned and mounted into the container

Useful for monorepos

Resolves ENG-1976

I'm still not sure if this is the best way to do it, but it works for now, want to discuss here the implementation in the GUI, and if there are missing pieces

EDIT: to change subfolder, you use `--recreate` also, so it can switch also container 