### PR TITLE
feat: inject DEVPOD and REMOTE_CONTAINERS env variables

### DIFF
--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -121,6 +121,14 @@ func (r *runner) runContainer(
 		}
 	}
 
+	// add environment variables that signals that we are in a remote container
+	// (vscode compatibility) and specifically that we are using devpod.
+	if runOptions.Env == nil {
+		runOptions.Env = make(map[string]string)
+	}
+	runOptions.Env["DEVPOD"] = "true"
+	runOptions.Env["REMOTE_CONTAINERS"] = "true"
+
 	// check if docker
 	dockerDriver, ok := r.Driver.(driver.DockerDriver)
 	if ok {

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -199,6 +199,11 @@ func (d *dockerDriver) RunDockerDevContainer(
 		"--sig-proxy=false",
 	}
 
+	// add environment variables that signals that we are in a remote container
+	// (vscode compatibility) and specifically that we are using devpod.
+	args = append(args, "--env", "DEVPOD=true")
+	args = append(args, "--env", "REMOTE_CONTAINERS=true")
+
 	// add ports
 	for _, appPort := range parsedConfig.AppPort {
 		intPort, err := strconv.Atoi(appPort)

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -199,11 +199,6 @@ func (d *dockerDriver) RunDockerDevContainer(
 		"--sig-proxy=false",
 	}
 
-	// add environment variables that signals that we are in a remote container
-	// (vscode compatibility) and specifically that we are using devpod.
-	args = append(args, "--env", "DEVPOD=true")
-	args = append(args, "--env", "REMOTE_CONTAINERS=true")
-
 	// add ports
 	for _, appPort := range parsedConfig.AppPort {
 		intPort, err := strconv.Atoi(appPort)


### PR DESCRIPTION
Inject the following env variables in the container:

REMOTE_CONTAINERS=true
DEVPOD=true

This will ensure that scripts and software running inside can detect that we are in a remote, devpod, container.

Fix #891 
Resolves ENG-2793 