### PR TITLE
otherPortsAttributes should be the attributes directly

### DIFF
--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -60,7 +60,7 @@ type DevContainerConfigBase struct {
 	PortsAttributes map[string]PortAttribute `json:"portAttributes,omitempty"`
 
 	// Set default properties that are applied to all ports that don't get properties from the setting `remote.portsAttributes`.
-	OtherPortsAttributes map[string]PortAttribute `json:"otherPortsAttributes,omitempty"`
+	OtherPortsAttributes *PortAttribute `json:"otherPortsAttributes,omitempty"`
 
 	// Controls whether on Linux the container's user should be updated with the local user's UID and GID. On by default when opening from a local folder.
 	UpdateRemoteUserUID *bool `json:"updateRemoteUserUID,omitempty"`

--- a/pkg/devcontainer/config/merge.go
+++ b/pkg/devcontainer/config/merge.go
@@ -60,9 +60,9 @@ func MergeConfiguration(config *DevContainerConfig, imageMetadataEntries []*Imag
 	return mergedConfig, nil
 }
 
-func mergeOtherPortsAttributes(entries []*ImageMetadata) map[string]PortAttribute {
+func mergeOtherPortsAttributes(entries []*ImageMetadata) *PortAttribute {
 	for _, entry := range entries {
-		if len(entry.OtherPortsAttributes) > 0 {
+		if entry.OtherPortsAttributes != nil {
 			return entry.OtherPortsAttributes
 		}
 	}


### PR DESCRIPTION
portAttributes are keyed by port, otherPortsAttributes are the
fallback for unnamed ports.
