### PR TITLE
feat(cli): rerun `runDevContainer` if driver supports it on existing …

### DIFF
--- a/cmd/agent/workspace/install_dotfiles.go
+++ b/cmd/agent/workspace/install_dotfiles.go
@@ -97,14 +97,26 @@ var scriptLocations = []string{
 func setupDotfiles(logger log.Logger) error {
 	for _, command := range scriptLocations {
 		logger.Debugf("Trying executing %s", command)
+		checkCmd := exec.Command("test", "-f", command)
+		err := checkCmd.Run()
+		if err != nil {
+			logger.Debugf("File %s not found", command)
+			continue
+		}
 
-		scriptCmd := exec.Command(command)
+		chmodCmd := exec.Command("chmod", "+x", command)
+		err = chmodCmd.Run()
+		if err != nil {
+			logger.Infof("Chmod of %s was unsuccessful: %v", command, err)
+			continue
+		}
 
 		writer := logger.Writer(logrus.InfoLevel, false)
 
+		scriptCmd := exec.Command(command)
 		scriptCmd.Stdout = writer
 		scriptCmd.Stderr = writer
-		err := scriptCmd.Run()
+		err = scriptCmd.Run()
 		if err != nil {
 			logger.Infof("Execution of %s was unsuccessful: %v", command, err)
 			logger.Debug("Trying next location")

--- a/pkg/driver/custom/custom.go
+++ b/pkg/driver/custom/custom.go
@@ -225,6 +225,12 @@ func (c *customDriver) RunDevContainer(ctx context.Context, workspaceId string, 
 	return nil
 }
 
+var _ driver.ReprovisioningDriver = (*customDriver)(nil)
+
+func (c *customDriver) CanReprovision() bool {
+	return c.workspaceInfo.Agent.Custom.CanReprovision == "true"
+}
+
 func (c *customDriver) runCommand(
 	ctx context.Context,
 	workspaceId string,

--- a/pkg/driver/types.go
+++ b/pkg/driver/types.go
@@ -31,6 +31,13 @@ type Driver interface {
 	StopDevContainer(ctx context.Context, workspaceId string) error
 }
 
+type ReprovisioningDriver interface {
+	Driver
+
+	// CanReprovision returns true if the driver can reprovision the devcontainer
+	CanReprovision() bool
+}
+
 // RunOptions are the options for running a container
 type RunOptions struct {
 	// Image is the image to run

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -167,6 +167,9 @@ type ProviderCustomDriverConfig struct {
 
 	// DeleteDevContainer is used to delete the devcontainer
 	DeleteDevContainer types.StrArray `json:"deleteDevContainer,omitempty"`
+
+	// CanReprovision returns true if the driver can reprovision the devcontainer
+	CanReprovision types.StrBool `json:"canReprovision,omitempty"`
 }
 
 type ProviderDockerDriverConfig struct {


### PR DESCRIPTION
Introduces `ReprovisioningDrivers` which can handle re-run workspace and optionally reprovision infrastructure if needed 