### PR TITLE
fix: sort feature variables to improve caching

### DIFF
--- a/pkg/devcontainer/feature/options.go
+++ b/pkg/devcontainer/feature/options.go
@@ -2,6 +2,7 @@ package feature
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/loft-sh/devpod/pkg/devcontainer/config"
 )
@@ -12,6 +13,8 @@ func getFeatureEnvVariables(feature *config.FeatureConfig, featureOptions interf
 	for k, v := range options {
 		variables = append(variables, fmt.Sprintf(`%s="%v"`, getFeatureSafeID(k), v))
 	}
+
+	sort.Strings(variables)
 
 	return variables
 }


### PR DESCRIPTION
Feature variables were pulled from a map, leading to random ordering. This caused the docker context to be randomly slightly different leading to build cache misses.