### PR TITLE
fix: fix recreate logic if workspace is local folder

### DIFF
--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -197,6 +197,12 @@ func prepareWorkspace(ctx context.Context, workspaceInfo *provider2.AgentWorkspa
 
 		return nil
 	} else if workspaceInfo.Workspace.Source.LocalFolder != "" {
+		// if we're not sending this to a remote machine, we're already done
+		if workspaceInfo.ContentFolder == workspaceInfo.Workspace.Source.LocalFolder {
+			log.Debugf("Local folder with local provider; skip downloading")
+			return nil
+		}
+
 		log.Debugf("Download Local Folder")
 		return DownloadLocalFolder(ctx, workspaceInfo.ContentFolder, client, log)
 	} else if workspaceInfo.Workspace.Source.Image != "" {

--- a/e2e/framework/command.go
+++ b/e2e/framework/command.go
@@ -100,6 +100,17 @@ func (f *Framework) DevPodUp(ctx context.Context, additionalArgs ...string) erro
 	return nil
 }
 
+func (f *Framework) DevPodUpRecreate(ctx context.Context, additionalArgs ...string) error {
+	upArgs := []string{"up", "--recreate", "--debug", "--ide", "none"}
+	upArgs = append(upArgs, additionalArgs...)
+
+	_, _, err := f.ExecCommandCapture(ctx, upArgs)
+	if err != nil {
+		return fmt.Errorf("devpod up --recreate failed: %s", err.Error())
+	}
+	return nil
+}
+
 func (f *Framework) DevPodSSH(ctx context.Context, workspace string, command string) (string, error) {
 	out, err := f.ExecCommandOutput(ctx, []string{"ssh", workspace, "--command", command})
 	if err != nil {


### PR DESCRIPTION
If a workspace is created from an actual local folder (as opposed to downloading a git repo) _and_ we're using a local provider, then `--recreate` should not try to download that folder again.

Without this fix I was seeing an EOF issue on recreate (likely files were trying to be copied to / from the same destination leading to file corruption). For example, my `.git/index` file was being corrupted by this issue, leading to git commands causing a segfault.