### PR TITLE
fix: Windows Runner cleanup

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -130,4 +130,4 @@ jobs:
         run: |
           Remove-Item -Recurse C:\Users\loft-user\.devpod\
           sh -c "docker ps -q -a | xargs docker rm -f || :"
-          sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep devpod | cut -d',' -f2 | xargs docker rmi -f || :"
+          sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep -E 'devpod|none' | cut -d',' -f2 | xargs docker rmi -f || :"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -130,4 +130,4 @@ jobs:
         run: |
           Remove-Item -Recurse C:\Users\loft-user\.devpod\
           sh -c "docker ps -q -a | xargs docker rm -f || :"
-          sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep -E 'devpod|none' | cut -d',' -f2 | xargs docker rmi -f || :"
+          sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep -E 'devpod|none|temp|^test' | cut -d',' -f2 | xargs docker rmi -f || :"

--- a/.github/workflows/e2e-win-full-tests.yaml
+++ b/.github/workflows/e2e-win-full-tests.yaml
@@ -51,4 +51,4 @@ jobs:
       run: |
         Remove-Item -Recurse C:\Users\loft-user\.devpod\
         sh -c "docker ps -q -a | xargs docker rm -f || :"
-        sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep -E 'devpod|none' | cut -d',' -f2 | xargs docker rmi -f || :"
+        sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep -E 'devpod|none|temp|^test' | cut -d',' -f2 | xargs docker rmi -f || :"

--- a/.github/workflows/e2e-win-full-tests.yaml
+++ b/.github/workflows/e2e-win-full-tests.yaml
@@ -51,4 +51,4 @@ jobs:
       run: |
         Remove-Item -Recurse C:\Users\loft-user\.devpod\
         sh -c "docker ps -q -a | xargs docker rm -f || :"
-        sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep devpod | cut -d',' -f2 | xargs docker rmi -f || :"
+        sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep -E 'devpod|none' | cut -d',' -f2 | xargs docker rmi -f || :"


### PR DESCRIPTION
Fix Windows Runner piling up images with `devpod` and `none` tags

![Screenshot from 2024-02-21 10-26-37](https://github.com/loft-sh/devpod/assets/598882/9bdfa930-4140-42f2-8c51-5c9ae4a3c12f)

