### PR TITLE
feat: add build cli options for buildx

### DIFF
--- a/pkg/devcontainer/build/options.go
+++ b/pkg/devcontainer/build/options.go
@@ -4,6 +4,8 @@ type BuildOptions struct {
 	BuildArgs map[string]string
 	Labels    map[string]string
 
+	CliOpts []string
+
 	Images    []string
 	CacheFrom []string
 

--- a/pkg/devcontainer/buildkit/buildkit.go
+++ b/pkg/devcontainer/buildkit/buildkit.go
@@ -105,6 +105,9 @@ func Build(ctx context.Context, client *buildkit.Client, writer io.Writer, platf
 		solveOptions.FrontendAttrs["build-arg:"+key] = value
 	}
 
+	// add additional build cli options
+	// TODO: convert options.CliOpts into a solveOptions.FrontendAttr
+
 	pw, err := NewPrinter(ctx, writer)
 	if err != nil {
 		return err

--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -257,6 +257,13 @@ func (d DockerfileContainer) GetArgs() map[string]string {
 	return nil
 }
 
+func (d DockerfileContainer) GetOptions() []string {
+	if d.Build != nil {
+		return d.Build.Options
+	}
+	return nil
+}
+
 func (d DockerfileContainer) GetCacheFrom() types.StrArray {
 	if d.Build != nil {
 		return d.Build.CacheFrom
@@ -279,6 +286,9 @@ type ConfigBuildOptions struct {
 
 	// The image to consider as a cache. Use an array to specify multiple images.
 	CacheFrom types.StrArray `json:"cacheFrom,omitempty"`
+
+	// Build cli options
+	Options []string `json:"options,omitempty"`
 }
 
 type HostRequirements struct {

--- a/pkg/driver/docker/build.go
+++ b/pkg/driver/docker/build.go
@@ -119,6 +119,9 @@ func CreateBuildOptions(
 	// get build args and target
 	buildOptions.BuildArgs, buildOptions.Target = GetBuildArgsAndTarget(parsedConfig, extendedBuildInfo)
 
+	// get cli options
+	buildOptions.CliOpts = parsedConfig.Config.GetOptions()
+
 	// get extended build info
 	buildOptions.Dockerfile, err = RewriteDockerfile(dockerfileContent, extendedBuildInfo)
 	if err != nil {
@@ -284,6 +287,9 @@ func (d *dockerDriver) buildxBuild(ctx context.Context, writer io.Writer, platfo
 	for _, cacheFrom := range options.CacheFrom {
 		args = append(args, "--cache-from", cacheFrom)
 	}
+
+	// add additional build cli options
+	args = append(args, options.CliOpts...)
 
 	// context
 	args = append(args, options.Context)


### PR DESCRIPTION
cli build options were recently added to the devcontainer spec (see https://github.com/devcontainers/spec/commit/d424cc157e9a110f3bf67d311b46c7306d5a465d ). let's add them here as well.

This can be useful for example to add a `--secret ...` to a `docker build`.

It's a little unclear currently how to add these to `pkg/devcontainer/buildkit/buildkit.go`. For now, I left a TODO. This would be no worse than the current behavior (as currently `build.options` is just ignored).