### PR TITLE
feat: move docker pull output to debug, denoise output

### DIFF
--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -95,6 +95,14 @@ func (r *DockerHelper) Stop(ctx context.Context, id string) error {
 	return nil
 }
 
+func (r *DockerHelper) Pull(ctx context.Context, image string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+	cmd := r.buildCmd(ctx, "pull", image)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
 func (r *DockerHelper) Remove(ctx context.Context, id string) error {
 	out, err := r.buildCmd(ctx, "rm", id).CombinedOutput()
 	if err != nil {

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -194,7 +194,7 @@ func (d *dockerDriver) RunDockerDevContainer(
 	ide string,
 	ideOptions map[string]config2.OptionValue,
 ) error {
-	err := d.EnsureImage(ctx, workspaceId, options, parsedConfig, init, ide, ideOptions)
+	err := d.EnsureImage(ctx, options)
 	if err != nil {
 		return err
 	}
@@ -326,12 +326,7 @@ func (d *dockerDriver) RunDockerDevContainer(
 
 func (d *dockerDriver) EnsureImage(
 	ctx context.Context,
-	workspaceId string,
 	options *driver.RunOptions,
-	parsedConfig *config.DevContainerConfig,
-	init *bool,
-	ide string,
-	ideOptions map[string]config2.OptionValue,
 ) error {
 	d.Log.Infof("Inspecting image %s", options.Image)
 	_, err := d.Docker.InspectImage(ctx, options.Image, false)


### PR DESCRIPTION
Denoise output for container pulling, moving the download progress to debug level.

To ensure this, we will inspect the image and pull it in a separate step before proceeding with the run command, this gives us the flexibility to relegate only the pull progress to debug output.

Regular output:

![image](https://github.com/loft-sh/devpod/assets/598882/be5f964c-f2d5-4e21-9169-d7c144e15085)


Debug output:

![image](https://github.com/loft-sh/devpod/assets/598882/5ad163d2-959d-41f3-98ba-d430d9c1ed92)


Resolves ENG-2936