### PR TITLE
feat: add dedicated logs entry in meatball menu

### DIFF
--- a/desktop/src/views/Workspaces/WorkspaceCard.tsx
+++ b/desktop/src/views/Workspaces/WorkspaceCard.tsx
@@ -177,7 +177,6 @@ export function WorkspaceCard({ workspaceID, onSelectionChange }: TWorkspaceCard
                     as={IconButton}
                     aria-label="More actions"
                     colorScheme="gray"
-                    isDisabled={isLoading}
                     icon={<Ellipsis transform={"rotate(90deg)"} boxSize={5} />}
                   />
                   <Portal>
@@ -190,7 +189,7 @@ export function WorkspaceCard({ workspaceID, onSelectionChange }: TWorkspaceCard
                           <MenuItem
                             ref={startWithRef}
                             icon={<Play boxSize={4} />}
-                            isDisabled={isOpenDisabled}>
+                            isDisabled={isOpenDisabled || isLoading }>
                             <HStack width="full" justifyContent="space-between">
                               <Text>Start with</Text>
                               <ChevronRightIcon boxSize={4} />
@@ -203,7 +202,7 @@ export function WorkspaceCard({ workspaceID, onSelectionChange }: TWorkspaceCard
                           ref={popoverContentRef}>
                           {ides?.map((ide) => (
                             <MenuItem
-                              isDisabled={isOpenDisabled}
+                              isDisabled={isOpenDisabled || isLoading }
                               onClick={handleOpenWithIDEClicked(id, ide.name)}
                               key={ide.name}
                               value={ide.name!}
@@ -216,7 +215,7 @@ export function WorkspaceCard({ workspaceID, onSelectionChange }: TWorkspaceCard
                       <MenuItem
                         icon={<ArrowPath boxSize={4} />}
                         onClick={onRebuildOpen}
-                        isDisabled={isOpenDisabled}>
+                        isDisabled={isOpenDisabled || isLoading }>
                         Rebuild
                       </MenuItem>
                       {isShareEnabled && (
@@ -250,6 +249,7 @@ export function WorkspaceCard({ workspaceID, onSelectionChange }: TWorkspaceCard
                         Logs
                       </MenuItem>
                       <MenuItem
+                        isDisabled={isOpenDisabled || isLoading }
                         fontWeight="normal"
                         icon={<Trash boxSize={4} />}
                         onClick={() => onDeleteOpen()}>

--- a/desktop/src/views/Workspaces/WorkspaceCard.tsx
+++ b/desktop/src/views/Workspaces/WorkspaceCard.tsx
@@ -53,7 +53,7 @@ import {
   useWorkspace,
   useWorkspaceActions,
 } from "../../contexts"
-import { ArrowPath, Ellipsis, Pause, Play, Stack3D, Trash } from "../../icons"
+import { ArrowPath, Ellipsis, Pause, Play, Stack3D, Trash, CommandLine } from "../../icons"
 import { NoWorkspaceImageSvg } from "../../images"
 import { getIDEDisplayName, useHover } from "../../lib"
 import { QueryKeys } from "../../queryKeys"
@@ -239,6 +239,15 @@ export function WorkspaceCard({ workspaceID, onSelectionChange }: TWorkspaceCard
                         }}
                         icon={<Pause boxSize={4} />}>
                         Stop
+                      </MenuItem>
+                      <MenuItem
+                        fontWeight="normal"
+                        icon={<CommandLine boxSize={4} />}
+                        onClick={() => {
+                          const actionID = workspace.checkStatus()
+                          navigateToAction(actionID)
+                        }}>
+                        Logs
                       </MenuItem>
                       <MenuItem
                         fontWeight="normal"


### PR DESCRIPTION
Adding a menu entry to show workspace logs, to improve discoverability of this feature

![image](https://github.com/loft-sh/devpod/assets/598882/44c4c364-cdf0-43f8-aab7-6a21913ccb67)

Fix #922 
Resolve ENG-2900