### PR TITLE
fix: improve cleanup images for windows runners

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -131,3 +131,4 @@ jobs:
           Remove-Item -Recurse C:\Users\loft-user\.devpod\
           sh -c "docker ps -q -a | xargs docker rm -f || :"
           sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep -E 'devpod|none|temp|^test' | cut -d',' -f2 | xargs docker rmi -f || :"
+          sh -c "docker images --format '{{.Tag}}|{{.Digest}}' | grep none | cut -d'|' -f1 | xargs docker rmi -f || :"

--- a/.github/workflows/e2e-win-full-tests.yaml
+++ b/.github/workflows/e2e-win-full-tests.yaml
@@ -52,3 +52,4 @@ jobs:
         Remove-Item -Recurse C:\Users\loft-user\.devpod\
         sh -c "docker ps -q -a | xargs docker rm -f || :"
         sh -c "docker images --format '{{.Repository}}:{{.Tag}},{{.ID}}' | grep -E 'devpod|none|temp|^test' | cut -d',' -f2 | xargs docker rmi -f || :"
+        sh -c "docker images --format '{{.ID}}|{{.Digest}}' | grep none | cut -d'|' -f1 | xargs docker rmi -f || :"


### PR DESCRIPTION
Improve Windows Runner image cleanup at the end of e2e tests

This should reduce flackyness

Resolves ENG-2969