### PR TITLE
fix(test): fix agent url on non-linux runners

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -122,14 +122,14 @@ jobs:
 
       - name: Build binary and copy to the E2E directory
         run: |
-          go build -ldflags "-s -w" -o devpod-windows-amd64.exe
           mkdir e2e\bin
-          cp devpod-windows-amd64.exe e2e\bin\
+          go build -ldflags "-s -w" -o e2e\bin\devpod-windows-amd64.exe
+          $Env:GOOS = "linux"; $Env:GOARCH = "amd64"; go build -ldflags "-s -w" -o e2e\bin\devpod-linux-amd64
 
       - name: E2E test
         working-directory: .\e2e
         run: |
-          go run github.com/onsi/ginkgo/v2/ginkgo -r -p --timeout=3600s --label-filter=${{ matrix.label }}
+          go run github.com/onsi/ginkgo/v2/ginkgo -r --timeout=3600s --label-filter=${{ matrix.label }}
 
       - name: Container cleanup
         if: ${{ always() }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -30,23 +30,21 @@ jobs:
       max-parallel: 16
       matrix:
         label:
-          [
-            "build",
-            "ide",
-            "integration",
-            "machine",
-            "machineprovider",
-            "provider",
-            "proxyprovider",
-            "ssh",
-            "up",
-            "up-docker",
-            "up-podman",
-            "up-docker-compose",
-            "up-docker-build",
-            "up-docker-compose-build",
-            "context",
-          ]
+          - "build"
+          - "ide"
+          - "integration"
+          - "machine"
+          - "machineprovider"
+          - "provider"
+          - "proxyprovider"
+          - "ssh"
+          - "up"
+          - "up-docker"
+          - "up-podman"
+          - "up-docker-compose"
+          - "up-docker-build"
+          - "up-docker-compose-build"
+          - "context"
 
     steps:
       - name: Checkout repo
@@ -97,15 +95,13 @@ jobs:
       max-parallel: 1
       matrix:
         label:
-          [
-            "build",
-            "ide",
-            "ssh",
-            "up-docker",
-            "up-docker-build",
-            "up-docker-compose",
-            "up-docker-wsl",
-          ]
+          - "build"
+          - "ide"
+          - "ssh"
+          - "up-docker"
+          - "up-docker-build"
+          - "up-docker-compose"
+          - "up-docker-wsl"
 
     steps:
       - name: Git set line ending

--- a/.github/workflows/e2e-win-full-tests.yaml
+++ b/.github/workflows/e2e-win-full-tests.yaml
@@ -20,15 +20,13 @@ jobs:
       max-parallel: 1
       matrix:
         label:
-          [
-            "build",
-            "ide",
-            "ssh",
-            "up-docker",
-            "up-docker-build",
-            "up-docker-compose",
-            "up-docker-wsl",
-          ]
+          - "build"
+          - "ide"
+          - "ssh"
+          - "up-docker"
+          - "up-docker-build"
+          - "up-docker-compose"
+          - "up-docker-wsl"
 
     steps:
     - name: Git set line ending

--- a/.github/workflows/e2e-win-full-tests.yaml
+++ b/.github/workflows/e2e-win-full-tests.yaml
@@ -19,8 +19,16 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        # windows blocklist: "up-podman", "integration", "machineprovider", "proxyprovider", "up"
-        label: ["build", "ide", "machine", "provider", "ssh", "up-docker", "up-docker-compose", "up-docker-build", "up-docker-compose-build", "up-docker-wsl"]
+        label:
+          [
+            "build",
+            "ide",
+            "ssh",
+            "up-docker",
+            "up-docker-build",
+            "up-docker-compose",
+            "up-docker-wsl",
+          ]
 
     steps:
     - name: Git set line ending
@@ -37,14 +45,14 @@ jobs:
 
     - name: Build binary and copy to the E2E directory
       run: |
-         go build -ldflags "-s -w" -o devpod-windows-amd64.exe
-         mkdir e2e\bin
-         cp devpod-windows-amd64.exe e2e\bin\
+        mkdir e2e\bin
+        go build -ldflags "-s -w" -o e2e\bin\devpod-windows-amd64.exe
+        $Env:GOOS = "linux"; $Env:GOARCH = "amd64"; go build -ldflags "-s -w" -o e2e\bin\devpod-linux-amd64
 
     - name: E2E test
       working-directory: .\e2e
       run: |
-        go run github.com/onsi/ginkgo/v2/ginkgo -r -p --timeout=3600s --label-filter=${{ matrix.label }}
+        go run github.com/onsi/ginkgo/v2/ginkgo -r --timeout=3600s --label-filter=${{ matrix.label }}
 
     - name: Container cleanup
       if: ${{ always() }}

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -1,11 +1,16 @@
 package e2e
 
 import (
+	"os"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 
 	"github.com/onsi/gomega"
+
+	"github.com/loft-sh/devpod/e2e/framework"
 
 	// Register tests
 	_ "github.com/loft-sh/devpod/e2e/tests/build"
@@ -26,6 +31,17 @@ import (
 // generated in this directory, and cluster logs will also be saved.
 // This function is called on each Ginkgo node in parallel mode.
 func TestRunE2ETests(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		go framework.ServeAgent()
+
+		// wait for http server to be up and running
+		for {
+			time.Sleep(time.Second)
+			if os.Getenv("DEVPOD_AGENT_URL") != "" {
+				break
+			}
+		}
+	}
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "DevPod e2e suite")
 }

--- a/e2e/framework/server_utils.go
+++ b/e2e/framework/server_utils.go
@@ -1,0 +1,108 @@
+package framework
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// serveAgent will be a simple http file server that will expose our
+// freshly compiled devpod binaries to be downloaded as agents.
+// useful for non-linux runners
+func ServeAgent() {
+	// Specify the directory containing the files you want to serve
+	dir := "bin"
+
+	wd, err := os.Getwd()
+	if err == nil {
+		dir = filepath.Join(wd, "bin")
+	}
+
+	// Create a file server handler for the specified directory
+	fileServer := http.FileServer(http.Dir(dir))
+
+	// Register the file server handler to serve files under the /files route
+	http.Handle("/files/", http.StripPrefix("/files", fileServer))
+
+	randomPort, err := findOpenPort(0)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ip := getIP()
+	addr := fmt.Sprintf("%s:%d", ip, randomPort)
+
+	err = os.Setenv("DEVPOD_AGENT_URL", "http://"+addr+"/files/")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Start the HTTP server on port 8080
+	log.Printf("Server started on %s", addr)
+	err = http.ListenAndServe(addr, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func findOpenPort(retries int) (int, error) {
+	if retries > 100 {
+		return 0, fmt.Errorf("no open port available in the range")
+	}
+	// Create a new random number generator with a custom seed (e.g., current time)
+	source := rand.NewSource(time.Now().UnixNano())
+	rng := rand.New(source)
+
+	min := 10000
+	max := 40000
+	port := rng.Intn(max-min+1) + min
+
+	conn, err := net.Dial("tcp", net.JoinHostPort("localhost", strconv.Itoa(port)))
+	if err == nil {
+		conn.Close()
+		return findOpenPort(retries + 1)
+	}
+
+	return port, nil
+}
+
+func getIP() string {
+	// Get a list of network interfaces
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "0.0.0.0"
+	}
+
+	// Iterate over each network interface
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return "0.0.0.0"
+		}
+
+		for _, addr := range addrs {
+			switch v := addr.(type) {
+			case *net.IPAddr:
+				if v.IP.To4() != nil {
+					if v.IP.DefaultMask().String() == "ffffff00" || v.IP.DefaultMask().String() == "ff000000" {
+						return v.IP.String()
+					}
+				}
+			case *net.IPNet:
+				if v.IP.To4() != nil {
+					if v.IP.DefaultMask().String() == "ffffff00" || v.IP.DefaultMask().String() == "ff000000" {
+						return v.IP.String()
+					}
+				}
+			}
+		}
+	}
+
+	return "0.0.0.0"
+}

--- a/e2e/framework/server_utils.go
+++ b/e2e/framework/server_utils.go
@@ -3,13 +3,10 @@ package framework
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
-	"time"
 )
 
 // serveAgent will be a simple http file server that will expose our
@@ -30,14 +27,14 @@ func ServeAgent() {
 	// Register the file server handler to serve files under the /files route
 	http.Handle("/files/", http.StripPrefix("/files", fileServer))
 
-	randomPort, err := findOpenPort(0)
+	ip := getIP()
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("%v:0", ip))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	ip := getIP()
-	addr := fmt.Sprintf("%s:%d", ip, randomPort)
-
+	addr := listener.Addr().String()
 	err = os.Setenv("DEVPOD_AGENT_URL", "http://"+addr+"/files/")
 	if err != nil {
 		log.Fatal(err)
@@ -45,31 +42,11 @@ func ServeAgent() {
 
 	// Start the HTTP server on port 8080
 	log.Printf("Server started on %s", addr)
-	err = http.ListenAndServe(addr, nil)
+
+	err = http.Serve(listener, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-func findOpenPort(retries int) (int, error) {
-	if retries > 100 {
-		return 0, fmt.Errorf("no open port available in the range")
-	}
-	// Create a new random number generator with a custom seed (e.g., current time)
-	source := rand.NewSource(time.Now().UnixNano())
-	rng := rand.New(source)
-
-	min := 10000
-	max := 40000
-	port := rng.Intn(max-min+1) + min
-
-	conn, err := net.Dial("tcp", net.JoinHostPort("localhost", strconv.Itoa(port)))
-	if err == nil {
-		conn.Close()
-		return findOpenPort(retries + 1)
-	}
-
-	return port, nil
 }
 
 func getIP() string {

--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -78,6 +78,10 @@ func InjectAgentAndExecute(
 	versionCheck := fmt.Sprintf(`[ "$(%s version 2>/dev/null || echo 'false')" != "%s" ]`, remoteAgentPath, version.GetVersion())
 	if version.GetVersion() == version.DevVersion {
 		preferDownload = false
+
+		if runtime.GOOS != "linux" {
+			preferDownload = true
+		}
 	}
 
 	// install devpod into the target


### PR DESCRIPTION
add way for non-linux runners to download a freshly compiled devpod binary as agent

Resolves ENG-3057