### PR TITLE
feat: add support for devcontainer up --workspace-env-file

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/loft-sh/devpod/cmd/flags"
 	"github.com/loft-sh/devpod/pkg/agent"
@@ -70,6 +72,10 @@ func NewUpCmd(flags *flags.GlobalFlags) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			// try to parse flags from env
 			err := mergeDevPodUpOptions(&cmd.CLIOptions)
+			if err != nil {
+				return err
+			}
+			err = mergeEnvFromFiles(&cmd.CLIOptions)
 			if err != nil {
 				return err
 			}
@@ -135,6 +141,7 @@ func NewUpCmd(flags *flags.GlobalFlags) *cobra.Command {
 	upCmd.Flags().BoolVar(&cmd.Reset, "reset", false, "If true will remove any existing containers including sources, and recreate them")
 	upCmd.Flags().StringSliceVar(&cmd.PrebuildRepositories, "prebuild-repository", []string{}, "Docker repository that hosts devpod prebuilds for this workspace")
 	upCmd.Flags().StringArrayVar(&cmd.WorkspaceEnv, "workspace-env", []string{}, "Extra env variables to put into the workspace. E.g. MY_ENV_VAR=MY_VALUE")
+	upCmd.Flags().StringArrayVar(&cmd.WorkspaceEnvFile, "workspace-env-file", []string{}, "The path to files containing a list of extra env variables to put into the workspace. E.g. MY_ENV_VAR=MY_VALUE")
 	upCmd.Flags().StringVar(&cmd.ID, "id", "", "The id to use for the workspace")
 	upCmd.Flags().StringVar(&cmd.Machine, "machine", "", "The machine to use for this workspace. The machine needs to exist beforehand or the command will fail. If the workspace already exists, this option has no effect")
 	upCmd.Flags().StringVar(&cmd.IDE, "ide", "", "The IDE to open the workspace in. If empty will use vscode locally or in browser")
@@ -738,6 +745,52 @@ func mergeDevPodUpOptions(baseOptions *provider2.CLIOptions) error {
 	}
 
 	return nil
+}
+
+func mergeEnvFromFiles(baseOptions *provider2.CLIOptions) error {
+	var variables []string
+	for _, file := range baseOptions.WorkspaceEnvFile {
+		envFromFile, err := parseKeyValueFile(file)
+		if err != nil {
+			return err
+		}
+		variables = append(variables, envFromFile...)
+	}
+	baseOptions.WorkspaceEnv = append(baseOptions.WorkspaceEnv, variables...)
+
+	return nil
+}
+
+func parseKeyValueFile(filename string) ([]string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	keyValuePairs := []string{}
+	scanner := bufio.NewScanner(f)
+	lineNum := 1
+	for scanner.Scan() {
+		scannedBytes := scanner.Bytes()
+		if !utf8.Valid(scannedBytes) {
+			return nil, fmt.Errorf("env file %s contains invalid utf8 bytes in line %d", filename, lineNum)
+		}
+		line := string(scannedBytes)
+		// skip commented or empty lines
+		if len(line) > 0 && !strings.HasPrefix(line, "#") {
+			key, value, found := strings.Cut(line, "=")
+			if len(key) == 0 || strings.Contains(key, " ") {
+				return nil, fmt.Errorf("env file %s contains invalid variable key in line %d: %s", filename, lineNum, line)
+			} else if len(value) == 0 {
+				return nil, fmt.Errorf("env file %s contains invalid variable value in line %d: %s", filename, lineNum, line)
+			}
+			if found {
+				keyValuePairs = append(keyValuePairs, line)
+			}
+		}
+		lineNum++
+	}
+	return keyValuePairs, nil
 }
 
 func createSSHCommand(

--- a/pkg/devcontainer/config/parse.go
+++ b/pkg/devcontainer/config/parse.go
@@ -1,11 +1,14 @@
 package config
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
 	path2 "path"
 	"path/filepath"
+	"strings"
+	"unicode/utf8"
 
 	doublestar "github.com/bmatcuk/doublestar/v4"
 	"github.com/pkg/errors"
@@ -165,4 +168,36 @@ func Convert(from interface{}, to interface{}) error {
 	}
 
 	return json.Unmarshal(out, to)
+}
+
+func ParseKeyValueFile(filename string) ([]string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	keyValuePairs := []string{}
+	scanner := bufio.NewScanner(f)
+	lineNum := 1
+	for scanner.Scan() {
+		scannedBytes := scanner.Bytes()
+		if !utf8.Valid(scannedBytes) {
+			return nil, fmt.Errorf("env file %s contains invalid utf8 bytes in line %d", filename, lineNum)
+		}
+		line := string(scannedBytes)
+		// skip commented or empty lines
+		if len(line) > 0 && !strings.HasPrefix(line, "#") {
+			key, value, found := strings.Cut(line, "=")
+			if len(key) == 0 || strings.Contains(key, " ") {
+				return nil, fmt.Errorf("env file %s contains invalid variable key in line %d: %s", filename, lineNum, line)
+			} else if len(value) == 0 {
+				return nil, fmt.Errorf("env file %s contains invalid variable value in line %d: %s", filename, lineNum, line)
+			}
+			if found {
+				keyValuePairs = append(keyValuePairs, line)
+			}
+		}
+		lineNum++
+	}
+	return keyValuePairs, nil
 }

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -172,6 +172,7 @@ type CLIOptions struct {
 	DevContainerImage    string   `json:"devContainerImage,omitempty"`
 	DevContainerPath     string   `json:"devContainerPath,omitempty"`
 	WorkspaceEnv         []string `json:"workspaceEnv,omitempty"`
+	WorkspaceEnvFile     []string `json:"workspaceEnvFile,omitempty"`
 	Recreate             bool     `json:"recreate,omitempty"`
 	Reset                bool     `json:"reset,omitempty"`
 	Proxy                bool     `json:"proxy,omitempty"`


### PR DESCRIPTION
Fixes #827

Each file from the list is parsed for key value pairs in the format `key=value` and merged with the remaining `--workspace-env` variables. 