### PR TITLE
Add docker builder option to provider

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -3,6 +3,7 @@ name: E2E tests
 on:
   release:
     types: [prereleased]
+  workflow_dispatch: {}
   pull_request:
     branches:
       - main

--- a/.github/workflows/e2e-win-full-tests.yaml
+++ b/.github/workflows/e2e-win-full-tests.yaml
@@ -3,6 +3,7 @@ name: E2E Win full tests
 on:
   release:
     types: [prereleased]
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/go-licenses-check.yaml
+++ b/.github/workflows/go-licenses-check.yaml
@@ -7,7 +7,7 @@ on:
     paths:
       - .github/workflows/go-licenses-check.yaml
       - go.mod
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,6 +18,33 @@ import (
 	perrors "github.com/pkg/errors"
 )
 
+// DockerBuilder represents the Docker builder types.
+type DockerBuilder int
+
+// Enum values for DockerBuilder.
+const (
+	DockerBuilderDefault DockerBuilder = iota
+	DockerBuilderBuildX
+	DockerBuilderBuildKit
+)
+
+func (db DockerBuilder) String() string {
+	return [...]string{"", "buildx", "buildkit"}[db]
+}
+
+func DockerBuilderFromString(s string) (DockerBuilder, error) {
+	switch s {
+	case "":
+		return DockerBuilderDefault, nil
+	case "buildkit":
+		return DockerBuilderBuildKit, nil
+	case "buildx":
+		return DockerBuilderBuildX, nil
+	default:
+		return DockerBuilderDefault, errors.New("invalid docker builder")
+	}
+}
+
 type DockerHelper struct {
 	DockerCommand string
 	// for a running container, we cannot pass down the container ID to the driver without introducing
@@ -25,6 +53,7 @@ type DockerHelper struct {
 	ContainerID string
 	// allow command to have a custom environment
 	Environment []string
+	Builder     DockerBuilder
 }
 
 func (r *DockerHelper) GPUSupportEnabled() (bool, error) {

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -34,10 +34,17 @@ func makeEnvironment(env map[string]string, log log.Logger) []string {
 	return ret
 }
 
-func NewDockerDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) driver.DockerDriver {
+func NewDockerDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) (driver.DockerDriver, error) {
 	dockerCommand := "docker"
 	if workspaceInfo.Agent.Docker.Path != "" {
 		dockerCommand = workspaceInfo.Agent.Docker.Path
+	}
+
+	var builder docker.DockerBuilder
+	var err error
+	builder, err = docker.DockerBuilderFromString(workspaceInfo.Agent.Docker.Builder)
+	if err != nil {
+		return nil, err
 	}
 
 	log.Debugf("Using docker command '%s'", dockerCommand)
@@ -46,9 +53,10 @@ func NewDockerDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger
 			DockerCommand: dockerCommand,
 			Environment:   makeEnvironment(workspaceInfo.Agent.Docker.Env, log),
 			ContainerID:   workspaceInfo.Workspace.Source.Container,
+			Builder:       builder,
 		},
 		Log: log,
-	}
+	}, nil
 }
 
 type dockerDriver struct {

--- a/pkg/driver/drivercreate/create.go
+++ b/pkg/driver/drivercreate/create.go
@@ -13,7 +13,7 @@ import (
 func NewDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) (driver.Driver, error) {
 	driver := workspaceInfo.Agent.Driver
 	if driver == "" || driver == provider2.DockerDriver {
-		return docker.NewDockerDriver(workspaceInfo, log), nil
+		return docker.NewDockerDriver(workspaceInfo, log)
 	} else if driver == provider2.CustomDriver {
 		return custom.NewCustomDriver(workspaceInfo, log), nil
 	} else if driver == "kubernetes" {

--- a/pkg/options/resolve.go
+++ b/pkg/options/resolve.go
@@ -221,6 +221,7 @@ func ResolveAgentConfig(devConfig *config.Config, provider *provider2.ProviderCo
 	agentConfig.Driver = resolver.ResolveDefaultValue(agentConfig.Driver, options)
 	agentConfig.Local = types.StrBool(resolver.ResolveDefaultValue(string(agentConfig.Local), options))
 	agentConfig.Docker.Path = resolver.ResolveDefaultValue(agentConfig.Docker.Path, options)
+	agentConfig.Docker.Builder = resolver.ResolveDefaultValue(agentConfig.Docker.Builder, options)
 	agentConfig.Docker.Install = types.StrBool(resolver.ResolveDefaultValue(string(agentConfig.Docker.Install), options))
 	agentConfig.Docker.Env = resolver.ResolveDefaultValues(agentConfig.Docker.Env, options)
 	agentConfig.DataPath = resolver.ResolveDefaultValue(agentConfig.DataPath, options)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -182,6 +182,9 @@ type ProviderDockerDriverConfig struct {
 	// If false, DevPod will not try to install docker into the machine.
 	Install types.StrBool `json:"install,omitempty"`
 
+	// Builder to use with docker
+	Builder string `json:"builder,omitempty"`
+
 	// Environment variables to set when running docker commands
 	Env map[string]string `json:"env,omitempty"`
 }

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -187,7 +187,6 @@ type CLIOptions struct {
 	SkipPush   bool     `json:"skipPush,omitempty"`
 	Platform   []string `json:"platform,omitempty"`
 
-	// TESTING
 	ForceBuild            bool `json:"forceBuild,omitempty"`
 	ForceDockerless       bool `json:"forceDockerless,omitempty"`
 	ForceInternalBuildKit bool `json:"forceInternalBuildKit,omitempty"`

--- a/providers/docker/provider.yaml
+++ b/providers/docker/provider.yaml
@@ -9,6 +9,7 @@ optionGroups:
       - DOCKER_PATH
       - DOCKER_HOST
       - INACTIVITY_TIMEOUT
+      - DOCKER_BUILDER
     name: "Advanced Options"
 options:
   INACTIVITY_TIMEOUT:
@@ -19,11 +20,15 @@ options:
   DOCKER_HOST:
     global: true
     description: The docker host to use.
+  DOCKER_BUILDER:
+    global: true
+    description: The docker builder to use.
 agent:
   containerInactivityTimeout: ${INACTIVITY_TIMEOUT}
   local: true
   docker:
     path: ${DOCKER_PATH}
+    builder: ${DOCKER_BUILDER}
     install: false
     env:
       DOCKER_HOST: ${DOCKER_HOST}


### PR DESCRIPTION
This PR solves #984 by first checking if podman is used when buildxExists is called and return true in this case.
It also adds a DOCKER_BUILDER option to the provider in order to choose easily between the 2 builders. 