### PR TITLE
Fix/SSH Conf: Generated ProxyCommand line is missing quotes around path

### DIFF
--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -67,11 +67,11 @@ func addHost(path, host, user, context, workspace, workdir, command string, gpga
 	newLines = append(newLines, "  UserKnownHostsFile /dev/null")
 	newLines = append(newLines, "  HostKeyAlgorithms rsa-sha2-256,rsa-sha2-512,ssh-rsa")
 	if command != "" {
-		newLines = append(newLines, fmt.Sprintf("  ProxyCommand %s", command))
+		newLines = append(newLines, fmt.Sprintf("  ProxyCommand \"%s\"", command))
 	} else if gpgagent {
-		newLines = append(newLines, fmt.Sprintf("  ProxyCommand %s ssh --gpg-agent-forwarding --stdio --context %s --user %s %s", execPath, context, user, workspace))
+		newLines = append(newLines, fmt.Sprintf("  ProxyCommand \"%s\" ssh --gpg-agent-forwarding --stdio --context %s --user %s %s", execPath, context, user, workspace))
 	} else {
-		proxyCommand := fmt.Sprintf("  ProxyCommand %s ssh --stdio --context %s --user %s %s", execPath, context, user, workspace)
+		proxyCommand := fmt.Sprintf("  ProxyCommand \"%s\" ssh --stdio --context %s --user %s %s", execPath, context, user, workspace)
 		if workdir != "" {
 			proxyCommand = fmt.Sprintf("%s --workdir %s", proxyCommand, workdir)
 		}


### PR DESCRIPTION
Fails to connect to DevPod on Windows over SSH since path for ProxyCommand in outputted `.ssh/config` is grabbed via `os.Executable()`, the default install location on Windows (`C:\Program Files`) has a space resulting in line:

```
  ProxyCommand C:\Program Files\.... ssh --stdio --context default --user devpod workspace-1"
```

Fixed by wrapping the path in escaped quotations