### PR TITLE
Preserve environment variables through sudo session

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -288,7 +288,7 @@ func rerunAsRoot(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) (b
 	}
 
 	// call ourself
-	args := []string{binary}
+	args := []string{"--preserve-env", binary}
 	args = append(args, os.Args[1:]...)
 	log.Debugf("Rerun as root: %s", strings.Join(args, " "))
 	cmd := exec.Command("sudo", args...)

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -107,6 +107,7 @@ func ExecuteCommand(
 
 		identityAgent := devsshagent.GetSSHAuthSocket()
 		if identityAgent != "" {
+			log.Debugf("Forwarding ssh-agent using %s", identityAgent)
 			err = devsshagent.ForwardToRemote(sshClient, identityAgent)
 			if err != nil {
 				errChan <- errors.Wrap(err, "forward agent")


### PR DESCRIPTION
When performing ssh clones on a machine where the Docker socket requires administrative access to utilize passing over the environment variables into the `sudo` session is required. 

It should also be noted, that Windows ships with OpenSSH 8.1 by default, so if Windows users are having issues with SSH Agent support they may need to upgrade their OpenSSH distribution to be inline or newer than the target machine's environment.