### PR TITLE
fix: quoted some more paths to handle spaces

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -283,7 +283,7 @@ func dockerlessBuild(
 	}
 
 	// build args
-	args := []string{"build", "--ignore-path", binaryPath}
+	args := []string{"build", "--ignore-path", fmt.Sprintf("'%s'", binaryPath)}
 	args = append(args, parseIgnorePaths(dockerlessOptions.IgnorePaths)...)
 	args = append(args, "--build-arg", "TARGETOS="+runtime.GOOS)
 	args = append(args, "--build-arg", "TARGETARCH="+runtime.GOARCH)
@@ -520,7 +520,7 @@ func configureSystemGitCredentials(ctx context.Context, cancel context.CancelFun
 		return nil, err
 	}
 
-	gitCredentials := fmt.Sprintf("%s agent git-credentials --port %d", binaryPath, serverPort)
+	gitCredentials := fmt.Sprintf("'%s' agent git-credentials --port %d", binaryPath, serverPort)
 	_ = os.Setenv("DEVPOD_GIT_HELPER_PORT", strconv.Itoa(serverPort))
 
 	err = git.CommandContext(ctx, "config", "--system", "--add", "credential.helper", gitCredentials).Run()

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -326,7 +326,7 @@ func configureCredentials(ctx context.Context, cancel context.CancelFunc, worksp
 
 	gitCredentials := ""
 	if workspaceInfo.Agent.InjectGitCredentials == "true" {
-		gitCredentials = fmt.Sprintf("%s agent git-credentials --port %d", binaryPath, serverPort)
+		gitCredentials = fmt.Sprintf("'%s' agent git-credentials --port %d", binaryPath, serverPort)
 		_ = os.Setenv("DEVPOD_GIT_HELPER_PORT", strconv.Itoa(serverPort))
 	}
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -288,7 +288,7 @@ func rerunAsRoot(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) (b
 	}
 
 	// call ourself
-	args := []string{binary}
+	args := []string{fmt.Sprintf("'%s'", binary)}
 	args = append(args, os.Args[1:]...)
 	log.Debugf("Rerun as root: %s", strings.Join(args, " "))
 	cmd := exec.Command("sudo", args...)

--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -75,7 +75,7 @@ func InjectAgentAndExecute(
 		downloadURL = DefaultAgentDownloadURL()
 	}
 
-	versionCheck := fmt.Sprintf(`[ "$(%s version 2>/dev/null || echo 'false')" != "%s" ]`, remoteAgentPath, version.GetVersion())
+	versionCheck := fmt.Sprintf(`[ "$('%s' version 2>/dev/null || echo 'false')" != "%s" ]`, remoteAgentPath, version.GetVersion())
 	if version.GetVersion() == version.DevVersion {
 		preferDownload = false
 

--- a/pkg/gitcredentials/gitcredentials.go
+++ b/pkg/gitcredentials/gitcredentials.go
@@ -42,10 +42,10 @@ func ConfigureHelper(binaryPath, userName string, port int) error {
 	}
 
 	config := string(out)
-	if !strings.Contains(config, fmt.Sprintf(`helper = "%s agent git-credentials --port %d"`, binaryPath, port)) {
+	if !strings.Contains(config, fmt.Sprintf(`helper = "'%s' agent git-credentials --port %d"`, binaryPath, port)) {
 		content := removeCredentialHelper(config) + fmt.Sprintf(`
 [credential]
-        helper = "%s agent git-credentials --port %d"
+        helper = "'%s' agent git-credentials --port %d"
 `, binaryPath, port)
 
 		err = os.WriteFile(gitConfigPath, []byte(content), 0600)

--- a/pkg/ide/fleet/fleet.go
+++ b/pkg/ide/fleet/fleet.go
@@ -177,7 +177,7 @@ func (o *FleetServer) startMonitor() error {
 
 	return single.Single("fleet-monitor.pid", func() (*exec.Cmd, error) {
 		o.log.Infof("Starting fleet monitor in background...")
-		runCommand := fmt.Sprintf("%s helper fleet-server --workspaceid %s", self, "test")
+		runCommand := fmt.Sprintf("'%s' helper fleet-server --workspaceid %s", self, "test")
 		args := []string{}
 		if o.userName != "" {
 			args = append(args, "su", o.userName, "-c", runCommand)

--- a/pkg/ide/fleet/fleet.go
+++ b/pkg/ide/fleet/fleet.go
@@ -121,7 +121,7 @@ func (o *FleetServer) Start(binaryPath, location, projectDir string) error {
 
 	err := single.Single("fleet.pid", func() (*exec.Cmd, error) {
 		o.log.Infof("Starting fleet in background...")
-		runCommand := fmt.Sprintf("%s launch workspace -- --projectDir '%s' --cache-path '%s' --auth=accept-everyone --publish --enableSmartMode", binaryPath, projectDir, location)
+		runCommand := fmt.Sprintf("'%s' launch workspace -- --projectDir '%s' --cache-path '%s' --auth=accept-everyone --publish --enableSmartMode", binaryPath, projectDir, location)
 		args := []string{}
 		if o.userName != "" {
 			args = append(args, "su", o.userName, "-c", runCommand)

--- a/pkg/ide/openvscode/openvscode.go
+++ b/pkg/ide/openvscode/openvscode.go
@@ -190,7 +190,7 @@ func (o *OpenVSCodeServer) installExtensions() error {
 	binaryPath := filepath.Join(location, "bin", "openvscode-server")
 	for _, extension := range o.extensions {
 		o.log.Info("Install extension " + extension + "...")
-		runCommand := fmt.Sprintf("%s --install-extension '%s'", binaryPath, extension)
+		runCommand := fmt.Sprintf("'%s' --install-extension '%s'", binaryPath, extension)
 		args := []string{}
 		if o.userName != "" {
 			args = append(args, "su", o.userName, "-c", runCommand)
@@ -261,7 +261,7 @@ func (o *OpenVSCodeServer) Start() error {
 
 	return single.Single("openvscode.pid", func() (*exec.Cmd, error) {
 		o.log.Infof("Starting openvscode in background...")
-		runCommand := fmt.Sprintf("%s server-local --without-connection-token --host '%s' --port '%s'", binaryPath, o.host, o.port)
+		runCommand := fmt.Sprintf("'%s' server-local --without-connection-token --host '%s' --port '%s'", binaryPath, o.host, o.port)
 		args := []string{}
 		if o.userName != "" {
 			args = append(args, "su", o.userName, "-c", runCommand)

--- a/pkg/ide/vscode/vscode.go
+++ b/pkg/ide/vscode/vscode.go
@@ -161,7 +161,7 @@ func (o *VsCodeServer) InstallExtensions() error {
 	// download extensions
 	for _, extension := range o.extensions {
 		o.log.Info("Install extension " + extension + "...")
-		runCommand := fmt.Sprintf("%s serve-local --accept-server-license-terms --install-extension '%s'", binPath, extension)
+		runCommand := fmt.Sprintf("'%s' serve-local --accept-server-license-terms --install-extension '%s'", binPath, extension)
 		args := []string{}
 		if o.userName != "" {
 			args = append(args, "su", o.userName, "-c", runCommand)

--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -73,7 +73,7 @@ func addHost(path, host, user, context, workspace, workdir, command string, gpga
 	} else {
 		proxyCommand := fmt.Sprintf("  ProxyCommand \"%s\" ssh --stdio --context %s --user %s %s", execPath, context, user, workspace)
 		if workdir != "" {
-			proxyCommand = fmt.Sprintf("%s --workdir %s", proxyCommand, workdir)
+			proxyCommand = fmt.Sprintf("'%s' --workdir '%s'", proxyCommand, workdir)
 		}
 		newLines = append(newLines, proxyCommand)
 	}

--- a/pkg/ssh/server/ssh.go
+++ b/pkg/ssh/server/ssh.go
@@ -166,7 +166,7 @@ func getShell() ([]string, error) {
 		return nil, err
 	}
 
-	return []string{executable, "helper", "sh"}, nil
+	return []string{fmt.Sprintf("'%s'", executable), "helper", "sh"}, nil
 }
 
 func (s *Server) handler(sess ssh.Session) {


### PR DESCRIPTION
I had some more time to look through the codebase and see if I can find any more paths that need to be quoted for support on Windows. I found another dozen or so (at least from what I can tell). Further to #1001 