### PR TITLE
feat(cli): add different git cloning strategies 

### DIFF
--- a/cmd/agent/workspace/install_dotfiles.go
+++ b/cmd/agent/workspace/install_dotfiles.go
@@ -51,7 +51,7 @@ func (cmd *InstallDotfilesCmd) Run(ctx context.Context) error {
 		logger.Infof("Cloning dotfiles %s", cmd.Repository)
 
 		gitInfo := git.NormalizeRepositoryGitInfo(cmd.Repository)
-		err = git.CloneRepository(ctx, gitInfo, targetDir, "", false, logger.Writer(logrus.DebugLevel, false), logger)
+		err = git.CloneRepository(ctx, gitInfo, targetDir, "", false, nil, logger.Writer(logrus.DebugLevel, false), logger)
 		if err != nil {
 			return err
 		}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -117,6 +117,7 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 	buildCmd.Flags().BoolVar(&cmd.SkipPush, "skip-push", false, "If true will not push the image to the repository, useful for testing")
 	buildCmd.Flags().StringVar(&cmd.GitBranch, "git-branch", "", "The git branch to use")
 	buildCmd.Flags().StringVar(&cmd.GitCommit, "git-commit", "", "The git commit SHA to use")
+	buildCmd.Flags().Var(&cmd.GitCloneStrategy, "git-clone-strategy", "The git clone strategy DevPod uses to checkout git based workspaces. Can be full (default), blobless, treeless or shallow")
 
 	// TESTING
 	buildCmd.Flags().BoolVar(&cmd.ForceBuild, "force-build", false, "TESTING ONLY")

--- a/cmd/helper/get_workspace_config.go
+++ b/cmd/helper/get_workspace_config.go
@@ -153,7 +153,7 @@ func findDevcontainerFiles(ctx context.Context, rawSource, tmpDirPath string, ma
 
 		gitInfo := git.NewGitInfo(gitRepository, gitBranch, gitCommit, gitPRReference, gitSubDir)
 		log.Debugf("Cloning git repository into %s", tmpDirPath)
-		err := git.CloneRepository(ctx, gitInfo, tmpDirPath, "", true, log.Writer(logrus.DebugLevel, false), log)
+		err := git.CloneRepository(ctx, gitInfo, tmpDirPath, "", true, git.NewCloner(git.ShallowCloneStrategy), log.Writer(logrus.DebugLevel, false), log)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -149,6 +149,7 @@ func NewUpCmd(flags *flags.GlobalFlags) *cobra.Command {
 	upCmd.Flags().BoolVar(&cmd.OpenIDE, "open-ide", true, "If this is false and an IDE is configured, DevPod will only install the IDE server backend, but not open it")
 	upCmd.Flags().StringVar(&cmd.GitBranch, "git-branch", "", "The git branch to use")
 	upCmd.Flags().StringVar(&cmd.GitCommit, "git-commit", "", "The git commit SHA to use")
+	upCmd.Flags().Var(&cmd.GitCloneStrategy, "git-clone-strategy", "The git clone strategy DevPod uses to checkout git based workspaces. Can be full (default), blobless, treeless or shallow")
 	upCmd.Flags().StringVar(&cmd.FallbackImage, "fallback-image", "", "The fallback image to use if no devcontainer configuration has been detected")
 
 	upCmd.Flags().BoolVar(&cmd.DisableDaemon, "disable-daemon", false, "If enabled, will not install a daemon into the target machine to track activity")

--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -1,0 +1,111 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/pflag"
+)
+
+type CloneStrategy string
+
+const (
+	FullCloneStrategy     CloneStrategy = ""
+	BloblessCloneStrategy CloneStrategy = "blobless"
+	TreelessCloneStrategy CloneStrategy = "treeless"
+	ShallowCloneStrategy  CloneStrategy = "shallow"
+)
+
+type Cloner interface {
+	Clone(ctx context.Context, repository string, targetDir string, extraArgs []string, stdout, stderr io.Writer) error
+}
+
+func NewCloner(strategy CloneStrategy) Cloner {
+	switch strategy {
+	case BloblessCloneStrategy:
+		return &bloblessClone{}
+	case TreelessCloneStrategy:
+		return &treelessClone{}
+	case ShallowCloneStrategy:
+		return &shallowClone{}
+	case FullCloneStrategy:
+		return &fullClone{}
+	default:
+		return &fullClone{}
+	}
+}
+
+var _ pflag.Value = (*CloneStrategy)(nil)
+
+func (s *CloneStrategy) Set(v string) error {
+	switch v {
+	case string(FullCloneStrategy),
+		string(BloblessCloneStrategy),
+		string(TreelessCloneStrategy),
+		string(ShallowCloneStrategy):
+		{
+			*s = CloneStrategy(v)
+			return nil
+		}
+	default:
+		return fmt.Errorf("CloneStrategy %s not supported", v)
+	}
+}
+func (s *CloneStrategy) Type() string {
+	return "cloneStrategy"
+}
+func (s *CloneStrategy) String() string {
+	return string(*s)
+}
+
+type fullClone struct{}
+
+var _ Cloner = &fullClone{}
+
+func (c *fullClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs []string, stdout, stderr io.Writer) error {
+	args := []string{"clone"}
+	args = append(args, extraArgs...)
+	args = append(args, repository, targetDir)
+	return run(ctx, args, stdout, stderr)
+}
+
+type bloblessClone struct{}
+
+var _ Cloner = &bloblessClone{}
+
+func (c *bloblessClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs []string, stdout, stderr io.Writer) error {
+	args := []string{"clone", "--filter=blob:none"}
+	args = append(args, extraArgs...)
+	args = append(args, repository, targetDir)
+	return run(ctx, args, stdout, stderr)
+}
+
+type treelessClone struct{}
+
+var _ Cloner = treelessClone{}
+
+func (c treelessClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs []string, stdout, stderr io.Writer) error {
+	args := []string{"clone", "--filter=tree:0"}
+	args = append(args, extraArgs...)
+	args = append(args, repository, targetDir)
+	return run(ctx, args, stdout, stderr)
+}
+
+type shallowClone struct{}
+
+var _ Cloner = shallowClone{}
+
+func (c shallowClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs []string, stdout, stderr io.Writer) error {
+	args := []string{"clone", "--depth=1"}
+	args = append(args, extraArgs...)
+	args = append(args, repository, targetDir)
+	return run(ctx, args, stdout, stderr)
+}
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	gitCommand := CommandContext(ctx, args...)
+	gitCommand.Stdout = stdout
+	gitCommand.Stderr = stderr
+	return gitCommand.Run()
+}

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -164,24 +164,25 @@ type AgentWorkspaceInfo struct {
 
 type CLIOptions struct {
 	// up options
-	ID                   string   `json:"id,omitempty"`
-	Source               string   `json:"source,omitempty"`
-	IDE                  string   `json:"ide,omitempty"`
-	IDEOptions           []string `json:"ideOptions,omitempty"`
-	PrebuildRepositories []string `json:"prebuildRepositories,omitempty"`
-	DevContainerImage    string   `json:"devContainerImage,omitempty"`
-	DevContainerPath     string   `json:"devContainerPath,omitempty"`
-	WorkspaceEnv         []string `json:"workspaceEnv,omitempty"`
-	WorkspaceEnvFile     []string `json:"workspaceEnvFile,omitempty"`
-	Recreate             bool     `json:"recreate,omitempty"`
-	Reset                bool     `json:"reset,omitempty"`
-	Proxy                bool     `json:"proxy,omitempty"`
-	DisableDaemon        bool     `json:"disableDaemon,omitempty"`
-	DaemonInterval       string   `json:"daemonInterval,omitempty"`
-	ForceCredentials     bool     `json:"forceCredentials,omitempty"`
-	GitBranch            string   `json:"gitBranch,omitempty"`
-	GitCommit            string   `json:"gitCommit,omitempty"`
-	FallbackImage        string   `json:"fallbackImage,omitempty"`
+	ID                   string            `json:"id,omitempty"`
+	Source               string            `json:"source,omitempty"`
+	IDE                  string            `json:"ide,omitempty"`
+	IDEOptions           []string          `json:"ideOptions,omitempty"`
+	PrebuildRepositories []string          `json:"prebuildRepositories,omitempty"`
+	DevContainerImage    string            `json:"devContainerImage,omitempty"`
+	DevContainerPath     string            `json:"devContainerPath,omitempty"`
+	WorkspaceEnv         []string          `json:"workspaceEnv,omitempty"`
+	WorkspaceEnvFile     []string          `json:"workspaceEnvFile,omitempty"`
+	Recreate             bool              `json:"recreate,omitempty"`
+	Reset                bool              `json:"reset,omitempty"`
+	Proxy                bool              `json:"proxy,omitempty"`
+	DisableDaemon        bool              `json:"disableDaemon,omitempty"`
+	DaemonInterval       string            `json:"daemonInterval,omitempty"`
+	ForceCredentials     bool              `json:"forceCredentials,omitempty"`
+	GitBranch            string            `json:"gitBranch,omitempty"`
+	GitCommit            string            `json:"gitCommit,omitempty"`
+	GitCloneStrategy     git.CloneStrategy `json:"gitCloneStrategy,omitempty"`
+	FallbackImage        string            `json:"fallbackImage,omitempty"`
 
 	// build options
 	Repository string   `json:"repository,omitempty"`


### PR DESCRIPTION
feat(cli): add different git cloning strategies and respective CLI flag --git-clone-strategy for git based workspaces. Possible values are: 
- "" (full clone, default behaviour) 
- blobless (full commit history and trees, no blobs) 
- treeless (full commit history, no trees nor blobs) 
- shallow (current HEAD, no history)