### PR TITLE
fix: trim v from semver

### DIFF
--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -143,7 +143,7 @@ func (h *ComposeHelper) Remove(ctx context.Context, projectName string, args []s
 }
 
 func (h *ComposeHelper) GetDefaultImage(projectName, serviceName string) (string, error) {
-	version, err := semver.Parse(h.Version)
+	version, err := semver.Parse(strings.TrimPrefix(h.Version, "v"))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixing `11:48:19 info Invalid character(s) found in major number "v2"` error received from `semver` package as my docker compose version is `v2.2.3`