### PR TITLE
fix(build): abolish builds for too old glibc.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,11 +108,6 @@ jobs:
             target: x86_64-pc-windows-msvc
             arch: amd64
             cli_only: false
-          - host: ubuntu-20.04
-            target: x86_64-unknown-linux-gnu
-            os: linux
-            arch: amd64
-            cli_only: false
           - host: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             os: linux
@@ -144,7 +139,7 @@ jobs:
         working-directory: "./desktop"
 
       - name: Setup System Dependencies
-        if: ( matrix.settings.host == 'ubuntu-22.04' || matrix.settings.host == 'ubuntu-20.04' ) && matrix.settings.cli_only == false
+        if: matrix.settings.host == 'ubuntu-22.04' && matrix.settings.cli_only == false
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev
@@ -199,28 +194,11 @@ jobs:
         run: yarn install
         working-directory: "./desktop"
 
-      - name: Build Desktop App (linux glibc old)
-        if: matrix.settings.host == 'ubuntu-20.04' && matrix.settings.cli_only == false
-        uses: tauri-apps/tauri-action@v0.4.0
-        with:
-          releaseId: glibc_old_${{ needs.create-release.outputs.release_id }}
-          projectPath: "./desktop"
-          args: "--config src-tauri/tauri-linux.conf.json --target ${{ matrix.settings.target }} --features enable-updater --bundles appimage,updater"
-          includeUpdaterJson: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-          # AppImage Signing:
-          SIGN: ${{ secrets.APP_IMAGE_SIGN }}
-          SIGN_KEY: ${{ secrets.APP_IMAGE_SIGN_KEY }}
-          APPIMAGETOOL_SIGN_PASSPHRASE: ${{ secrets.APP_IMAGE_SIGN_PASSPHRASE }}
-
-      - name: Build Desktop App (linux glibc new)
+      - name: Build Desktop App
         if: matrix.settings.host == 'ubuntu-22.04' && matrix.settings.cli_only == false
         uses: tauri-apps/tauri-action@v0.4.0
         with:
-          releaseId: glibc_new_${{ needs.create-release.outputs.release_id }}
+          releaseId: ${{ needs.create-release.outputs.release_id }}
           projectPath: "./desktop"
           args: "--config src-tauri/tauri-linux.conf.json --target ${{ matrix.settings.target }} --features enable-updater --bundles appimage,updater"
           includeUpdaterJson: true
@@ -254,23 +232,14 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
 
-      - name: Build linux tar.gz (glibc old)
-        if: matrix.settings.host == 'ubuntu-20.04' && matrix.settings.cli_only == false
-        id: build-desktop-targz-glibc-old
-        run: |
-          cd ./desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/appimage/dev-pod.AppDir || exit 1
-          tar --exclude=usr/bin/xdg-open --exclude=usr/lib --exclude=usr/share/doc --exclude=usr/share/glib-2.0 -zcvf dev-pod-desktop.tar.gz usr
-
-          mv dev-pod-desktop.tar.gz ../../dev-pod-glibc-old-${{needs.create-release.outputs.package_version}}.tar.gz
-
-      - name: Build linux tar.gz (glibc new)
+      - name: Build linux tar.gz
         if: matrix.settings.host == 'ubuntu-22.04' && matrix.settings.cli_only == false
-        id: build-desktop-targz-glibc-new
+        id: build-desktop-targz
         run: |
           cd ./desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/appimage/dev-pod.AppDir || exit 1
           tar --exclude=usr/bin/xdg-open --exclude=usr/lib --exclude=usr/share/doc --exclude=usr/share/glib-2.0 -zcvf dev-pod-desktop.tar.gz usr
 
-          mv dev-pod-desktop.tar.gz ../../dev-pod-glibc-new-${{needs.create-release.outputs.package_version}}.tar.gz
+          mv dev-pod-desktop.tar.gz ../../dev-pod-${{needs.create-release.outputs.package_version}}.tar.gz
 
       - name: Build Desktop App
         if: matrix.settings.host == 'windows-latest' && matrix.settings.cli_only == false
@@ -357,7 +326,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload CLI Asset
-        if: matrix.settings.host != 'windows-latest' && matrix.settings.host != 'ubuntu-20.04'
+        if: matrix.settings.host != 'windows-latest'
         uses: actions/github-script@v6
         with:
           script: |
@@ -383,52 +352,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload AppImage Assets (glibc old)
-        if: matrix.settings.host == 'ubuntu-20.04' && matrix.settings.cli_only == false
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const fs = require("fs")
-
-            const releaseId = "${{ needs.create-release.outputs.release_id }}"
-
-            const assetName = "dev-pod_${{needs.create-release.outputs.package_version}}_amd64.AppImage"
-            const assetUploadName = "dev-pod-glibc-old_${{needs.create-release.outputs.package_version}}_amd64.AppImage"
-            const assetPath = `desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/appimage/${assetName}`
-
-            const tarAssetName = "dev-pod_${{needs.create-release.outputs.package_version}}_amd64.AppImage.tar.gz"
-            const tarAssetUploadName = "dev-pod-glibc-old_${{needs.create-release.outputs.package_version}}_amd64.AppImage.tar.gz"
-            const tarAssetPath = `desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/appimage/${tarAssetName}`
-
-            console.log("Attempting to upload release asset: ", assetName)
-
-            await github.rest.repos.uploadReleaseAsset({
-              headers: {
-                "content-type": "application/zip",
-                "content-length": fs.statSync(assetPath).size
-              },
-              name: assetUploadName,
-              data: fs.readFileSync(assetPath),
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: releaseId
-            })
-
-            await github.rest.repos.uploadReleaseAsset({
-              headers: {
-                "content-type": "application/zip",
-                "content-length": fs.statSync(assetPath).size
-              },
-              name: tarAssetUploadName,
-              data: fs.readFileSync(tarAssetPath),
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: releaseId
-            })
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload AppImage Assets (glibc new)
+      - name: Upload Tar.gz Asset
         if: matrix.settings.host == 'ubuntu-22.04' && matrix.settings.cli_only == false
         uses: actions/github-script@v6
         with:
@@ -436,79 +360,7 @@ jobs:
             const fs = require("fs")
 
             const releaseId = "${{ needs.create-release.outputs.release_id }}"
-
-            const assetName = "dev-pod_${{needs.create-release.outputs.package_version}}_amd64.AppImage"
-            const assetUploadName = "dev-pod-glibc-new_${{needs.create-release.outputs.package_version}}_amd64.AppImage"
-            const assetPath = `desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/appimage/${assetName}`
-
-            const tarAssetName = "dev-pod_${{needs.create-release.outputs.package_version}}_amd64.AppImage.tar.gz"
-            const tarAssetUploadName = "dev-pod-glibc-new_${{needs.create-release.outputs.package_version}}_amd64.AppImage.tar.gz"
-            const tarAssetPath = `desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/appimage/${tarAssetName}`
-
-            console.log("Attempting to upload release asset: ", assetName)
-
-            await github.rest.repos.uploadReleaseAsset({
-              headers: {
-                "content-type": "application/zip",
-                "content-length": fs.statSync(assetPath).size
-              },
-              name: assetUploadName,
-              data: fs.readFileSync(assetPath),
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: releaseId
-            })
-
-            await github.rest.repos.uploadReleaseAsset({
-              headers: {
-                "content-type": "application/zip",
-                "content-length": fs.statSync(assetPath).size
-              },
-              name: tarAssetUploadName,
-              data: fs.readFileSync(tarAssetPath),
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: releaseId
-            })
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload Tar.gz Asset (glibc old)
-        if: matrix.settings.host == 'ubuntu-20.04' && matrix.settings.cli_only == false
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const fs = require("fs")
-
-            const releaseId = "${{ needs.create-release.outputs.release_id }}"
-            const assetName = "dev-pod-glibc-old-${{needs.create-release.outputs.package_version}}.tar.gz"
-            const assetPath = `desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/${assetName}`
-
-            console.log("Attempting to upload release asset: ", assetName)
-
-            await github.rest.repos.uploadReleaseAsset({
-              headers: {
-                "content-type": "application/zip",
-                "content-length": fs.statSync(assetPath).size
-              },
-              name: assetName,
-              data: fs.readFileSync(assetPath),
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: releaseId
-            })
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload Tar.gz Asset (glibc new)
-        if: matrix.settings.host == 'ubuntu-22.04' && matrix.settings.cli_only == false
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const fs = require("fs")
-
-            const releaseId = "${{ needs.create-release.outputs.release_id }}"
-            const assetName = "dev-pod-glibc-new-${{needs.create-release.outputs.package_version}}.tar.gz"
+            const assetName = "dev-pod-${{needs.create-release.outputs.package_version}}.tar.gz"
             const assetPath = `desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/${assetName}`
 
             console.log("Attempting to upload release asset: ", assetName)
@@ -606,15 +458,11 @@ jobs:
             const winVersion = latest.version.replace("-", ".")
 
             const infos = [
-              { target: "linux-x86_64", sigFile: ".AppImage.tar.gz.sig", packageType: ".tar.gz", originalAssetName: `dev-pod-glibc-old_${version}_amd64.AppImage`, desiredAssetName: "DevPod_linux_glibc_old_amd64.AppImage" },
-              { target: "linux-x86_64", sigFile: ".AppImage.tar.gz.sig", packageType: ".tar.gz", originalAssetName: `dev-pod-glibc-new_${version}_amd64.AppImage`, desiredAssetName: "DevPod_linux_glibc_new_amd64.AppImage" },
+              { target: "linux-x86_64", sigFile: ".AppImage.tar.gz.sig", packageType: ".tar.gz", originalAssetName: `dev-pod_${version}_amd64.AppImage`, desiredAssetName: "DevPod_linux_amd64.AppImage" },
               { target: "darwin-aarch64", sigFile: "aarch64.app.tar.gz.sig", packageType: ".tar.gz", originalAssetName: `DevPod_${version}_aarch64.dmg`, desiredAssetName: "DevPod_macos_aarch64.dmg", originalUpdaterAssetName: "DevPod_aarch64.app.tar.gz", desiredUpdaterAssetName: "DevPod_macos_aarch64.app.tar.gz" },
               { target: "darwin-x86_64", sigFile: "x64.app.tar.gz.sig", packageType: ".tar.gz", originalAssetName: `DevPod_${version}_x64.dmg`, desiredAssetName: "DevPod_macos_x64.dmg", originalUpdaterAssetName: "DevPod_x64.app.tar.gz", desiredUpdaterAssetName: "DevPod_macos_x64.app.tar.gz" },
               { target: "windows-x86_64", sigFile: ".msi.zip.sig", packageType: ".zip", originalAssetName: `DevPod_${winVersion}_x64_en-US.msi`, desiredAssetName: "DevPod_windows_x64_en-US.msi" },
-              { originalAssetName: `dev-pod-glibc-new-${version}.tar.gz`, desiredAssetName: "DevPod_linux_glibc_new_x86_64.tar.gz" },
-              { originalAssetName: `dev-pod-glibc-old-${version}.tar.gz`, desiredAssetName: "DevPod_linux_glibc_old_x86_64.tar.gz" },
-              { originalAssetName: `dev-pod-glibc-new-${version}_amd64.AppImage`, desiredAssetName: "DevPod_linux_glibc_new_x86_64.AppImage" },
-              { originalAssetName: `dev-pod-glibc-old-${version}_amd64.AppImage`, desiredAssetName: "DevPod_linux_glibc_old_x86_64.AppImage" },
+              { originalAssetName: `dev-pod-${version}.tar.gz`, desiredAssetName: "DevPod_linux_x86_64.tar.gz" },
             ]
 
             for (const info of infos) {

--- a/docs/pages/getting-started/install.mdx
+++ b/docs/pages/getting-started/install.mdx
@@ -15,8 +15,7 @@ Download DevPod Desktop:
 - [MacOS Silicon/ARM](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_macos_aarch64.dmg)
 - [MacOS Intel/AMD](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_macos_x64.dmg)
 - [Windows](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_windows_x64_en-US.msi)
-- [Linux AppImage (old distros)](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_linux_glibc_old_x86_64.AppImage)
-- [Linux AppImage (new distros)](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_linux_glibc_new_x86_64.AppImage)
+- [Linux AppImage](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_linux_amd64.AppImage)
 - [Linux Targz](https://github.com/loft-sh/devpod/releases/latest/download/DevPod_linux_x86_64.tar.gz)
 
 :::info Previous Releases
@@ -24,22 +23,14 @@ For previous releases, please take a look at the [Github releases page](https://
 :::
 
 :::info Linux Packages
-**The official package is the Appimage**, there are two versions:
+**The official package is the Appimage**, it has been tested working on:
 
-- Old glibc
-	- Debian 11 and older
-	- Ubuntu 20.04 and older
-	- Fedora 30 and older
-	- Centos 9stream and newer
-	- RHEL/Alma Linux/Rocky Linux 9 and newer
-
-- New glibc
-	- Debian 12 and newer
-	- Ubuntu 22.04 and newer
-	- Fedora 32 and newer
-	- Opensuse Leap 15.3 and newer
-	- Opensuse Tumbleweed
-	- Archlinux
+- Debian 12 and newer
+- Ubuntu 22.04 and newer
+- Fedora 36 and newer
+- Opensuse Leap 15.3 and newer
+- Opensuse Tumbleweed
+- Archlinux
 
 Make sure you have the following dependencies installed for the Appimage to work (usually already installed in desktop distributions):
 


### PR DESCRIPTION
Basically revert all the "glibc-old" compatibility commits

We need glibg 2.35+
Update the compatibility list to reflect this