### PR TITLE
feat(cli): allow users to specify AGENT_URL with ${BIN_NAME} argument

### DIFF
--- a/pkg/inject/download_urls.go
+++ b/pkg/inject/download_urls.go
@@ -2,10 +2,12 @@ package inject
 
 import (
 	"net/url"
+	"strings"
 )
 
 const AmdUrl = "devpod-linux-amd64"
 const ArmUrl = "devpod-linux-arm64"
+const BinNamePlaceholder = "${BIN_NAME}"
 
 type DownloadURLs struct {
 	Base string
@@ -14,8 +16,17 @@ type DownloadURLs struct {
 }
 
 func NewDownloadURLs(baseUrl string) *DownloadURLs {
-	amdUrl, _ := url.JoinPath(baseUrl, AmdUrl)
-	armUrl, _ := url.JoinPath(baseUrl, ArmUrl)
+	var amdUrl, armUrl string
+
+	// replace ${BIN_NAME} with binary name
+	if strings.Contains(baseUrl, BinNamePlaceholder) {
+		baseUrl = strings.TrimSuffix(baseUrl, "/")
+		amdUrl = strings.Replace(baseUrl, BinNamePlaceholder, AmdUrl, 1)
+		armUrl = strings.Replace(baseUrl, BinNamePlaceholder, ArmUrl, 1)
+	} else {
+		amdUrl, _ = url.JoinPath(baseUrl, AmdUrl)
+		armUrl, _ = url.JoinPath(baseUrl, ArmUrl)
+	}
 
 	return &DownloadURLs{
 		Base: baseUrl,


### PR DESCRIPTION
The arg will be substituted with the agent binary name to allow for
more customized Agent URLs like presigned s3 URLs

solves #1102 