### PR TITLE
Remove redundant error checks

### DIFF
--- a/cmd/agent/container/openvscode_async.go
+++ b/cmd/agent/container/openvscode_async.go
@@ -46,10 +46,5 @@ func (cmd *OpenVSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
 	}
 
 	// install IDE
-	err = setupOpenVSCodeExtensions(setupInfo, log.Default)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return setupOpenVSCodeExtensions(setupInfo, log.Default)
 }

--- a/cmd/agent/container/vscode_async.go
+++ b/cmd/agent/container/vscode_async.go
@@ -49,10 +49,5 @@ func (cmd *VSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
 	}
 
 	// install IDE
-	err = setupVSCodeExtensions(setupInfo, vscode.ReleaseChannel(cmd.ReleaseChannel), log.Default)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return setupVSCodeExtensions(setupInfo, vscode.ReleaseChannel(cmd.ReleaseChannel), log.Default)
 }

--- a/cmd/agent/container_tunnel.go
+++ b/cmd/agent/container_tunnel.go
@@ -85,7 +85,7 @@ func (cmd *ContainerTunnelCmd) Run(ctx context.Context, log log.Logger) error {
 	}()
 
 	// create tunnel into container.
-	err = agent.Tunnel(
+	return agent.Tunnel(
 		ctx,
 		func(ctx context.Context, user string, command string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
 			return runner.Command(ctx, user, command, stdin, stdout, stderr)
@@ -96,11 +96,6 @@ func (cmd *ContainerTunnelCmd) Run(ctx context.Context, log log.Logger) error {
 		os.Stderr,
 		log,
 	)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func startDevContainer(ctx context.Context, workspaceConfig *provider2.AgentWorkspaceInfo, runner devcontainer.Runner, log log.Logger) error {

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -387,14 +387,9 @@ func DownloadLocalFolder(ctx context.Context, workspaceDir string, client tunnel
 
 func PrepareImage(workspaceDir, image string) error {
 	// create a .devcontainer.json with the image
-	err := os.WriteFile(filepath.Join(workspaceDir, ".devcontainer.json"), []byte(`{
+	return os.WriteFile(filepath.Join(workspaceDir, ".devcontainer.json"), []byte(`{
   "image": "`+image+`"
 }`), 0o600)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (cmd *UpCmd) devPodUp(ctx context.Context, workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) (*config2.Result, error) {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -129,12 +129,7 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 
 func (cmd *BuildCmd) Run(ctx context.Context, client client.WorkspaceClient) error {
 	// build workspace
-	err := cmd.build(ctx, client, log.Default)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.build(ctx, client, log.Default)
 }
 
 func (cmd *BuildCmd) build(ctx context.Context, workspaceClient client.WorkspaceClient, log log.Logger) error {

--- a/cmd/helper/ssh_client.go
+++ b/cmd/helper/ssh_client.go
@@ -55,12 +55,7 @@ func (cmd *SSHClient) Run(ctx context.Context, args []string) error {
 	sess.Stdin = os.Stdin
 	sess.Stdout = os.Stdout
 	sess.Stderr = os.Stderr
-	err = sess.Run(command2.Quote(args))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return sess.Run(command2.Quote(args))
 }
 
 func (cmd *SSHClient) getConfig() (*ssh.ClientConfig, error) {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -104,12 +104,7 @@ func (cmd *ImportCmd) Run(ctx context.Context, devPodConfig *config.Config, log 
 	}
 
 	// import workspace
-	err = cmd.importWorkspace(devPodConfig, exportConfig, log)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.importWorkspace(devPodConfig, exportConfig, log)
 }
 
 func (cmd *ImportCmd) importWorkspace(devPodConfig *config.Config, exportConfig *provider.ExportConfig, log log.Logger) error {

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -111,10 +111,5 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 
 	session.Stdout = os.Stdout
 	session.Stderr = os.Stderr
-	err = session.Run(agentCommand)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return session.Run(agentCommand)
 }

--- a/cmd/machine/create.go
+++ b/cmd/machine/create.go
@@ -46,10 +46,5 @@ func (cmd *CreateCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	err = machineClient.Create(ctx, client.CreateOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return machineClient.Create(ctx, client.CreateOptions{})
 }

--- a/cmd/machine/delete.go
+++ b/cmd/machine/delete.go
@@ -63,13 +63,8 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 		}
 	}
 
-	err = machineClient.Delete(ctx, client.DeleteOptions{
+	return machineClient.Delete(ctx, client.DeleteOptions{
 		Force:       cmd.Force,
 		GracePeriod: cmd.GracePeriod,
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -188,10 +188,5 @@ func StartSSHSession(ctx context.Context, user, command string, agentForwarding 
 	}
 
 	// wait until done
-	err = session.Wait()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return session.Wait()
 }

--- a/cmd/machine/start.go
+++ b/cmd/machine/start.go
@@ -44,10 +44,5 @@ func (cmd *StartCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	err = machineClient.Start(ctx, client.StartOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return machineClient.Start(ctx, client.StartOptions{})
 }

--- a/cmd/machine/stop.go
+++ b/cmd/machine/stop.go
@@ -44,10 +44,5 @@ func (cmd *StopCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	err = machineClient.Stop(ctx, client.StopOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return machineClient.Stop(ctx, client.StopOptions{})
 }

--- a/cmd/pro/import_workspace.go
+++ b/cmd/pro/import_workspace.go
@@ -152,12 +152,7 @@ func (cmd *ImportCmd) writeWorkspaceDefinition(devPodConfig *config.Config, prov
 	}
 	workspaceObj.Provider.Options = devPodConfig.Current().Providers[provider.Name].Options
 
-	err = provider2.SaveWorkspaceConfig(workspaceObj)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return provider2.SaveWorkspaceConfig(workspaceObj)
 }
 
 func resolveProInstance(devPodConfig *config.Config, devPodProHost string, log log.Logger) (*provider2.ProviderConfig, error) {

--- a/cmd/pro/login.go
+++ b/cmd/pro/login.go
@@ -257,11 +257,8 @@ func login(ctx context.Context, devPodConfig *config.Config, url string, provide
 		}
 		err = loader.Login(url, true, log)
 	}
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 func LoftConfigPath(devPodConfig *config.Config, providerName string) (string, error) {

--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -1057,12 +1057,7 @@ func (cmd *StartCmd) login(url string) error {
 	}
 
 	// log into the UI
-	err = cmd.loginUI(url)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.loginUI(url)
 }
 
 func (cmd *StartCmd) loginViaCLI(url string) error {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -71,12 +71,7 @@ func (cmd *StopCmd) Run(ctx context.Context, devPodConfig *config.Config, client
 	}
 
 	// stop environment
-	err = client.Stop(ctx, client2.StopOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return client.Stop(ctx, client2.StopOptions{})
 }
 
 func (cmd *StopCmd) stopSingleMachine(ctx context.Context, client client2.BaseWorkspaceClient, devPodConfig *config.Config) (bool, error) {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -592,12 +592,7 @@ func startFleet(ctx context.Context, client client2.BaseWorkspaceClient, logger 
 		"Fleet is exposed at a publicly reachable URL, please make sure to not disclose this URL to anyone as they will be able to reach your workspace from that",
 	)
 	logger.Infof("Starting Fleet at %s ...", url)
-	err = open.Run(url)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return open.Run(url)
 }
 
 func startVSCodeInBrowser(
@@ -750,11 +745,8 @@ func startBrowserTunnel(
 			return nil
 		},
 	)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 func configureSSH(c *config.Config, client client2.BaseWorkspaceClient, sshConfigPath, user, workdir string, gpgagent bool) error {
@@ -764,7 +756,7 @@ func configureSSH(c *config.Config, client client2.BaseWorkspaceClient, sshConfi
 	}
 	sshConfigPath = path
 
-	err = devssh.ConfigureSSHConfig(
+	return devssh.ConfigureSSHConfig(
 		sshConfigPath,
 		client.Context(),
 		client.Workspace(),
@@ -773,11 +765,6 @@ func configureSSH(c *config.Config, client client2.BaseWorkspaceClient, sshConfi
 		gpgagent,
 		log.Default,
 	)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func mergeDevPodUpOptions(baseOptions *provider2.CLIOptions) error {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -332,12 +332,7 @@ func Tunnel(
 	}
 
 	// create tunnel
-	err = exec(ctx, user, command, stdin, stdout, stderr)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return exec(ctx, user, command, stdin, stdout, stderr)
 }
 
 func dockerReachable(dockerOverride string, envs map[string]string) (bool, error) {

--- a/pkg/binaries/download.go
+++ b/pkg/binaries/download.go
@@ -413,10 +413,5 @@ func copyLocal(binary *provider2.ProviderBinary, targetPath string) error {
 		}
 	}
 
-	err = copy.File(binary.Path, targetPath, 0755)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return copy.File(binary.Path, targetPath, 0755)
 }

--- a/pkg/client/clientimplementation/machine_client.go
+++ b/pkg/client/clientimplementation/machine_client.go
@@ -276,12 +276,7 @@ func (s *machineClient) Delete(ctx context.Context, options client.DeleteOptions
 	s.log.Donef("Successfully deleted machine '%s'", s.machine.ID)
 
 	// delete machine folder
-	err = DeleteMachineFolder(s.machine.Context, s.machine.ID)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return DeleteMachineFolder(s.machine.Context, s.machine.ID)
 }
 
 func runCommand(ctx context.Context, name string, command types.StrArray, environ []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, log log.Logger) (err error) {

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -198,7 +198,7 @@ func (s *proxyClient) Ssh(ctx context.Context, opt client.SshOptions) error {
 		readLogStream(reader, s.log.ErrorStreamOnly())
 	}()
 
-	err := RunCommandWithBinaries(
+	return RunCommandWithBinaries(
 		ctx,
 		"ssh",
 		s.config.Exec.Proxy.Ssh,
@@ -213,11 +213,6 @@ func (s *proxyClient) Ssh(ctx context.Context, opt client.SshOptions) error {
 		writer,
 		s.log.ErrorStreamOnly(),
 	)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (s *proxyClient) Delete(ctx context.Context, opt client.DeleteOptions) error {

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -595,12 +595,7 @@ func RunCommand(ctx context.Context, command types.StrArray, environ []string, s
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	cmd.Env = environ
-	err := cmd.Run()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.Run()
 }
 
 func DeleteMachineFolder(context, machineID string) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -299,10 +299,5 @@ func SaveConfig(config *Config) error {
 		return err
 	}
 
-	err = os.WriteFile(configOrigin, out, 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(configOrigin, out, 0600)
 }

--- a/pkg/copy/copy.go
+++ b/pkg/copy/copy.go
@@ -139,11 +139,7 @@ func File(srcFile, dstFile string, perm os.FileMode) error {
 	defer in.Close()
 
 	_, err = io.Copy(out, in)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func Exists(filePath string) bool {

--- a/pkg/devcontainer/buildkit/buildkit.go
+++ b/pkg/devcontainer/buildkit/buildkit.go
@@ -115,9 +115,5 @@ func Build(ctx context.Context, client *buildkit.Client, writer io.Writer, platf
 
 	// build
 	_, err = client.Solve(ctx, nil, solveOptions, pw.Status())
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -55,12 +55,7 @@ func (r *runner) stopDockerCompose(ctx context.Context, projectName string) erro
 		return errors.Wrap(err, "get compose/env files")
 	}
 
-	err = composeHelper.Stop(ctx, projectName, composeGlobalArgs)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return composeHelper.Stop(ctx, projectName, composeGlobalArgs)
 }
 
 func (r *runner) deleteDockerCompose(ctx context.Context, projectName string) error {
@@ -79,12 +74,7 @@ func (r *runner) deleteDockerCompose(ctx context.Context, projectName string) er
 		return errors.Wrap(err, "get compose/env files")
 	}
 
-	err = composeHelper.Remove(ctx, projectName, composeGlobalArgs)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return composeHelper.Remove(ctx, projectName, composeGlobalArgs)
 }
 
 func (r *runner) dockerComposeProjectFiles(parsedConfig *config.SubstitutedConfig) ([]string, []string, []string, error) {

--- a/pkg/devcontainer/config/parse.go
+++ b/pkg/devcontainer/config/parse.go
@@ -59,12 +59,7 @@ func SaveDevContainerJSON(config *DevContainerConfig) error {
 		return err
 	}
 
-	err = os.WriteFile(config.Origin, out, 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(config.Origin, out, 0600)
 }
 
 func ParseDevContainerJSON(folder, relativePath string) (*DevContainerConfig, error) {

--- a/pkg/devcontainer/config/substitute.go
+++ b/pkg/devcontainer/config/substitute.go
@@ -55,12 +55,7 @@ func Substitute(substitutionCtx *SubstitutionContext, config interface{}, out in
 		return replaceWithContext(isWindows, substitutionCtx, match, variable, args)
 	})
 
-	err = Convert(retVal, out)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return Convert(retVal, out)
 }
 
 func SubstituteContainerEnv(containerEnv map[string]string, config interface{}, out interface{}) error {
@@ -75,12 +70,7 @@ func SubstituteContainerEnv(containerEnv map[string]string, config interface{}, 
 		return replaceWithContainerEnv(containerEnv, match, variable, args)
 	})
 
-	err = Convert(retVal, out)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return Convert(retVal, out)
 }
 
 func replaceWithContainerEnv(containerEnv map[string]string, match, variable string, args []string) string {

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -265,12 +265,7 @@ func PostCreateCommands(setupInfo *config.Result, log log.Logger) error {
 	}
 
 	// run always when attaching to the container
-	err = runPostCreateCommand(mergedConfig.PostAttachCommands, remoteUser, setupInfo.SubstitutionContext.ContainerWorkspaceFolder, setupInfo.MergedConfig.RemoteEnv, "postAttachCommands", "", log)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return runPostCreateCommand(mergedConfig.PostAttachCommands, remoteUser, setupInfo.SubstitutionContext.ContainerWorkspaceFolder, setupInfo.MergedConfig.RemoteEnv, "postAttachCommands", "", log)
 }
 
 func markerFileExists(markerName string, markerContent string) (bool, error) {

--- a/pkg/dockercredentials/dockercredentials.go
+++ b/pkg/dockercredentials/dockercredentials.go
@@ -78,12 +78,7 @@ func configureCredentials(userName, shebang string, targetDir, configDir string,
 		return err
 	}
 
-	err = file.Chown(userName, dockerConfig.Filename)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return file.Chown(userName, dockerConfig.Filename)
 }
 
 func ConfigureCredentialsDockerless(targetFolder string, port int, log log.Logger) (string, error) {

--- a/pkg/driver/custom/custom.go
+++ b/pkg/driver/custom/custom.go
@@ -71,7 +71,7 @@ func (c *customDriver) FindDevContainer(ctx context.Context, workspaceId string)
 // CommandDevContainer runs the given command inside the devcontainer
 func (c *customDriver) CommandDevContainer(ctx context.Context, workspaceId, user, command string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
 	// run command
-	err := c.runCommand(
+	return c.runCommand(
 		ctx,
 		workspaceId,
 		"commandDevContainer",
@@ -85,11 +85,6 @@ func (c *customDriver) CommandDevContainer(ctx context.Context, workspaceId, use
 		},
 		c.log,
 	)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // TargetArchitecture returns the architecture of the container runtime. e.g. amd64 or arm64

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -115,12 +115,7 @@ func (d *dockerDriver) DeleteDevContainer(ctx context.Context, workspaceId strin
 		return nil
 	}
 
-	err = d.Docker.Remove(ctx, container.ID)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return d.Docker.Remove(ctx, container.ID)
 }
 
 func (d *dockerDriver) StartDevContainer(ctx context.Context, workspaceId string) error {
@@ -346,12 +341,7 @@ func (d *dockerDriver) RunDockerDevContainer(
 	writer := d.Log.Writer(logrus.InfoLevel, false)
 	defer writer.Close()
 
-	err = d.Docker.Run(ctx, args, nil, writer, writer)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return d.Docker.Run(ctx, args, nil, writer, writer)
 }
 
 func (d *dockerDriver) EnsureImage(

--- a/pkg/ide/openvscode/openvscode.go
+++ b/pkg/ide/openvscode/openvscode.go
@@ -232,12 +232,7 @@ func (o *OpenVSCodeServer) installSettings() error {
 		return err
 	}
 
-	err = copy2.ChownR(location, o.userName)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return copy2.ChownR(location, o.userName)
 }
 
 func (o *OpenVSCodeServer) Start() error {

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -37,12 +37,7 @@ func CheckPushPermissions(image string) error {
 		return err
 	}
 
-	err = remote.CheckPushPermission(ref, authn.DefaultKeychain, http.DefaultTransport)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return remote.CheckPushPermission(ref, authn.DefaultKeychain, http.DefaultTransport)
 }
 
 func GetImageConfig(ctx context.Context, image string) (*v1.ConfigFile, v1.Image, error) {

--- a/pkg/options/resolver/util.go
+++ b/pkg/options/resolver/util.go
@@ -109,12 +109,7 @@ func addOptionsToGraph(g *graph.Graph[*types.Option], optionDefinitions config.O
 	}
 
 	// add dependencies
-	err := addDependencies(g, optionDefinitions, optionValues)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return addDependencies(g, optionDefinitions, optionValues)
 }
 
 func deleteChildrenOf(graph *graph.Graph[*types.Option], node *graph.Node[*types.Option]) error {

--- a/pkg/provider/dir.go
+++ b/pkg/provider/dir.go
@@ -172,12 +172,7 @@ func SaveProviderConfig(context string, provider *ProviderConfig) error {
 	}
 
 	providerConfigFile := filepath.Join(providerDir, ProviderConfigFile)
-	err = os.WriteFile(providerConfigFile, providerDirBytes, 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(providerConfigFile, providerDirBytes, 0600)
 }
 
 func SaveProInstanceConfig(context string, proInstance *ProInstance) error {
@@ -197,12 +192,7 @@ func SaveProInstanceConfig(context string, proInstance *ProInstance) error {
 	}
 
 	proInstanceConfigFile := filepath.Join(providerDir, ProInstanceConfigFile)
-	err = os.WriteFile(proInstanceConfigFile, proInstanceBytes, 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(proInstanceConfigFile, proInstanceBytes, 0600)
 }
 
 func SaveWorkspaceResult(workspace *Workspace, result *config2.Result) error {
@@ -222,12 +212,7 @@ func SaveWorkspaceResult(workspace *Workspace, result *config2.Result) error {
 	}
 
 	workspaceResultFile := filepath.Join(workspaceDir, WorkspaceResultFile)
-	err = os.WriteFile(workspaceResultFile, resultBytes, 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(workspaceResultFile, resultBytes, 0600)
 }
 
 func SaveWorkspaceConfig(workspace *Workspace) error {
@@ -247,12 +232,7 @@ func SaveWorkspaceConfig(workspace *Workspace) error {
 	}
 
 	workspaceConfigFile := filepath.Join(workspaceDir, WorkspaceConfigFile)
-	err = os.WriteFile(workspaceConfigFile, workspaceConfigBytes, 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(workspaceConfigFile, workspaceConfigBytes, 0600)
 }
 
 func SaveMachineConfig(machine *Machine) error {
@@ -272,12 +252,7 @@ func SaveMachineConfig(machine *Machine) error {
 	}
 
 	machineConfigFile := filepath.Join(machineDir, MachineConfigFile)
-	err = os.WriteFile(machineConfigFile, machineConfigBytes, 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(machineConfigFile, machineConfigBytes, 0600)
 }
 
 func MachineExists(context, machineID string) bool {

--- a/pkg/provider/parse.go
+++ b/pkg/provider/parse.go
@@ -116,12 +116,7 @@ func validate(config *ProviderConfig) error {
 		return err
 	}
 
-	err = validateOptionGroups(config)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return validateOptionGroups(config)
 }
 
 func validateProviderType(config *ProviderConfig) error {

--- a/pkg/single/single.go
+++ b/pkg/single/single.go
@@ -79,10 +79,5 @@ func Single(file string, createCommand CreateCommand) error {
 	}
 
 	// release process resources
-	err = cmd.Process.Release()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.Process.Release()
 }

--- a/pkg/ssh/helper.go
+++ b/pkg/ssh/helper.go
@@ -111,10 +111,5 @@ func Run(ctx context.Context, client *ssh.Client, command string, stdin io.Reade
 	sess.Stdin = stdin
 	sess.Stdout = stdout
 	sess.Stderr = stderr
-	err = sess.Run(command)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return sess.Run(command)
 }

--- a/pkg/ssh/server/ssh.go
+++ b/pkg/ssh/server/ssh.go
@@ -257,12 +257,7 @@ func (s *Server) HandleNonPTY(sess ssh.Session, cmd *exec.Cmd) (err error) {
 	}()
 
 	waitGroup.Wait()
-	err = cmd.Wait()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.Wait()
 }
 
 func HandlePTY(

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -700,12 +700,7 @@ func loadExistingWorkspace(workspaceID string, devPodConfig *config.Config, chan
 
 func saveWorkspaceConfig(workspace *provider2.Workspace) error {
 	// save config
-	err := provider2.SaveWorkspaceConfig(workspace)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return provider2.SaveWorkspaceConfig(workspace)
 }
 
 func createMachine(context, machineID, providerName string) (*provider2.Machine, error) {


### PR DESCRIPTION
This PR removes the repeating redundant error checks:

```
err := someFunc()
if err != nil {
   return err
} 

return nil
```

Instead, directly returning removes redundancy and makes code more readable like this:

```
return someFunc()
```