### PR TITLE
Add alias for `stop` command

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -24,8 +24,9 @@ func NewStopCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	stopCmd := &cobra.Command{
-		Use:   "stop",
-		Short: "Stops an existing workspace",
+		Use:     "stop",
+		Aliases: []string{"down"},
+		Short:   "Stops an existing workspace",
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()
 			devPodConfig, err := config.LoadConfig(cmd.Context, cmd.Provider)

--- a/e2e/framework/command.go
+++ b/e2e/framework/command.go
@@ -169,7 +169,7 @@ func (f *Framework) DevPodStatus(ctx context.Context, extraArgs ...string) (clie
 	baseArgs = append(baseArgs, extraArgs...)
 	stdout, err := f.ExecCommandOutput(ctx, baseArgs)
 	if err != nil {
-		return client.WorkspaceStatus{}, fmt.Errorf("devpod stop failed: %s", err.Error())
+		return client.WorkspaceStatus{}, fmt.Errorf("devpod status failed: %s", err.Error())
 	}
 
 	status := &client.WorkspaceStatus{}


### PR DESCRIPTION
Adds alias `down` for `stop` command to make CLI a bit more consistent - `devpod up` now has counterpart of `devpod down`

Fixes typo in `e2e/framework/command.go:DevPodStatus`

