### PR TITLE
Update install.mdx

### DIFF
--- a/docs/pages/getting-started/install.mdx
+++ b/docs/pages/getting-started/install.mdx
@@ -93,7 +93,7 @@ curl -L -o devpod "https://github.com/loft-sh/devpod/releases/latest/download/de
 
 ```text
 md -Force "$Env:APPDATA\devpod"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
-Invoke-WebRequest -URI "https://github.com/loft-sh/devpod/releases/latest/download/devpod-windows-amd64.exe" -o $Env:APPDATA\devpod\devpod.exe;
+Invoke-WebRequest -URI "https://github.com/loft-sh/devpod/releases/latest/download/devpod-windows-amd64.exe" -OutFile $Env:APPDATA\devpod\devpod.exe;
 $env:Path += ";" + $Env:APPDATA + "\devpod";
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
 ```


### PR DESCRIPTION
The `-o` option is ambiguous. 

Invoke-WebRequest: Parameter cannot be processed because the parameter name 'o' is ambiguous. Possible matches include: -OperationTimeoutSeconds -OutFile -OutVariable -OutBuffer.