### PR TITLE
fix(cli): use container user to setup git config

### DIFF
--- a/cmd/agent/container/credentials_server.go
+++ b/cmd/agent/container/credentials_server.go
@@ -134,7 +134,7 @@ func (cmd *CredentialsServerCmd) Run(ctx context.Context, _ []string) error {
 
 func configureGitUserLocally(ctx context.Context, userName string, client tunnel.TunnelClient) error {
 	// get local credentials
-	localGitUser, err := gitcredentials.GetUser()
+	localGitUser, err := gitcredentials.GetUser(userName)
 	if err != nil {
 		return err
 	} else if localGitUser.Name != "" && localGitUser.Email != "" {

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -177,7 +177,7 @@ func (t *tunnelServer) DockerCredentials(ctx context.Context, message *tunnel.Me
 }
 
 func (t *tunnelServer) GitUser(ctx context.Context, empty *tunnel.Empty) (*tunnel.Message, error) {
-	gitUser, err := gitcredentials.GetUser()
+	gitUser, err := gitcredentials.GetUser("")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When setting up .gitconfig in the workspace we attempt to read existing
settings and only fetch the user and email from the host machine if they
aren't already defined.
This never worked because we run the credentials server as root, thus
reading `git config --global user.xxx` from the root users gitconfig
which doesn't exist by default.
We now use retrieve the global gitconfig location by following
https://git-scm.com/docs/git-config/#Documentation/git-config.txt-XDGCONFIGHOMEgitconfig
