### PR TITLE
Add <cluster-name> to `devpod pro add cluster` command usage

### DIFF
--- a/cmd/pro/add/cluster.go
+++ b/cmd/pro/add/cluster.go
@@ -54,7 +54,7 @@ func NewClusterCmd(globalFlags *proflags.GlobalFlags) *cobra.Command {
 	}
 
 	c := &cobra.Command{
-		Use:   "cluster",
+		Use:   "cluster <cluster-name>",
 		Short: "add current cluster to DevPod Pro",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Currently there is no way for user to know what argument this command expects just from `--help` message. 

