### PR TITLE
Pod 763/ expose execute timeout as context option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /e2e/bin
 devpod
 devpod.exe
+devpod-cli
 # Unit test targets
 main
 profile.out

--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -8,8 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"time"
 
+	"github.com/loft-sh/devpod/pkg/config"
 	devpodhttp "github.com/loft-sh/devpod/pkg/http"
 	"github.com/loft-sh/devpod/pkg/inject"
 	"github.com/loft-sh/devpod/pkg/shell"
@@ -105,6 +107,16 @@ func InjectAgentAndExecute(
 			ShouldChmodPath:     true,
 		}
 
+		// Get the timeout from the context options
+		var timeout int64 = 20
+		devPodConfig := config.Get()
+		if devPodConfig != nil {
+			t, err := strconv.ParseInt(devPodConfig.ContextOption(config.ContextOptionExitAfterTimeout), 10, 64)
+			if err == nil {
+				timeout = t
+			}
+		}
+
 		wasExecuted, err := inject.InjectAndExecute(
 			ctx,
 			exec,
@@ -115,7 +127,7 @@ func InjectAgentAndExecute(
 			stdin,
 			stdout,
 			stderr,
-			time.Second*20,
+			time.Second*time.Duration(timeout),
 			log,
 		)
 		if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var env *Config
+
 type Config struct {
 	// DefaultContext is the default context to use. Defaults to "default"
 	DefaultContext string `json:"defaultContext,omitempty"`
@@ -272,6 +274,7 @@ func LoadConfig(contextOverride string, providerOverride string) (*Config, error
 		}()
 	}
 
+	env = config
 	return config, nil
 }
 
@@ -305,4 +308,9 @@ func SaveConfig(config *Config) error {
 	}
 
 	return nil
+}
+
+// Get returns the environment's context options, it assumes LoadConfig has been called previously to populate env
+func Get() *Config {
+	return env
 }

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -13,6 +13,7 @@ const (
 	ContextOptionDotfilesScript             = "DOTFILES_SCRIPT"
 	ContextOptionSSHAgentForwarding         = "SSH_AGENT_FORWARDING"
 	ContextOptionSSHConfigPath              = "SSH_CONFIG_PATH"
+	ContextOptionExecuteTimeout             = "EXECUTE_TIMEOUT"
 )
 
 var ContextOptions = []ContextOption{
@@ -79,5 +80,10 @@ var ContextOptions = []ContextOption{
 	{
 		Name:        ContextOptionSSHConfigPath,
 		Description: "Specifies the path where the ssh config should be written to",
+	},
+	{
+		Name:        ContextOptionExecuteTimeout,
+		Description: "Specifies the timeout in seconds used when injecting and executing devpod's agent binary",
+		Default:     "20",
 	},
 }


### PR DESCRIPTION
This PR fixes POD-763 by providing a new context option EXECUTE_TIMEOUT to set the timeout in seconds, instead of a hard coded value.

Additionally I have added a function to get the environment's current context options. Currently the context is loaded and it's pointer is expected to be passed round to any function that needs the config. Instead we now assign a variable during LoadConfig to act as a singleton, so it can easily be retrieved without updating lots of function signatures.

To test this PR I have run `./devpod-cli up examples/simple` to ensure injecting the binary still works, I also ran `./devpod-cli context options` to ensure the option is listed and `./devpod-cli context set-options default -o EXECUTE_TIMEOUT=60` to ensure it can be updated.