### PR TITLE
POD-755: Fix workspace ID when branch is specified

### DIFF
--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -441,11 +441,11 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			err = f.DevPodUp(ctx, "https://github.com/loft-sh/examples/@subpath:/devpod/jupyter-notebook-hello-world")
 			framework.ExpectNoError(err)
 
-			out, err := f.DevPodSSH(ctx, "jupyter-notebook-hello-world", "pwd")
+			out, err := f.DevPodSSH(ctx, "subpath-devpod-jupyter-notebook-hello-world", "pwd")
 			framework.ExpectNoError(err)
-			framework.ExpectEqual(out, "/workspaces/jupyter-notebook-hello-world\n", "should be subpath")
+			framework.ExpectEqual(out, "/workspaces/subpath-devpod-jupyter-notebook-hello-world\n", "should be subpath")
 
-			err = f.DevPodWorkspaceDelete(ctx, "jupyter-notebook-hello-world")
+			err = f.DevPodWorkspaceDelete(ctx, "subpath-devpod-jupyter-notebook-hello-world")
 			framework.ExpectNoError(err)
 		})
 

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -441,11 +441,12 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			err = f.DevPodUp(ctx, "https://github.com/loft-sh/examples/@subpath:/devpod/jupyter-notebook-hello-world")
 			framework.ExpectNoError(err)
 
-			out, err := f.DevPodSSH(ctx, "subpath--devpod-jupyter-notebook-hello-world", "pwd")
+			id := "subpath--devpod-jupyter-notebook-hello-world"
+			out, err := f.DevPodSSH(ctx, id, "pwd")
 			framework.ExpectNoError(err)
-			framework.ExpectEqual(out, "/workspaces/subpath--devpod-jupyter-notebook-hello-world\n", "should be subpath")
+			framework.ExpectEqual(out, fmt.Sprintf("/workspaces/%s\n", id), "should be subpath")
 
-			err = f.DevPodWorkspaceDelete(ctx, "subpath--devpod-jupyter-notebook-hello-world")
+			err = f.DevPodWorkspaceDelete(ctx, id)
 			framework.ExpectNoError(err)
 		})
 
@@ -465,20 +466,21 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 				framework.ExpectNoError(err)
 			})
 
+			id := "subpath--devpod-jupyter-notebook-hello-world"
 			err = f.DevPodUp(ctx, "https://github.com/loft-sh/examples/@subpath:/devpod/jupyter-notebook-hello-world")
 			framework.ExpectNoError(err)
 
-			_, err = f.DevPodSSH(ctx, "jupyter-notebook-hello-world", "pwd")
+			_, err = f.DevPodSSH(ctx, id, "pwd")
 			framework.ExpectNoError(err)
 
 			// recreate
 			err = f.DevPodUpRecreate(ctx, "https://github.com/loft-sh/examples/@subpath:/devpod/jupyter-notebook-hello-world")
 			framework.ExpectNoError(err)
 
-			_, err = f.DevPodSSH(ctx, "jupyter-notebook-hello-world", "pwd")
+			_, err = f.DevPodSSH(ctx, id, "pwd")
 			framework.ExpectNoError(err)
 
-			err = f.DevPodWorkspaceDelete(ctx, "jupyter-notebook-hello-world")
+			err = f.DevPodWorkspaceDelete(ctx, id)
 			framework.ExpectNoError(err)
 		})
 
@@ -500,13 +502,14 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 				framework.ExpectNoError(err)
 			})
 
+			id := "subpath--devpod-jupyter-notebook-hello-world"
 			err = f.DevPodUp(ctx, "https://github.com/loft-sh/examples/@subpath:/devpod/jupyter-notebook-hello-world")
 			framework.ExpectNoError(err)
 
 			// create files in root and in workspace, after create we expect data to still be there
-			_, err = f.DevPodSSH(ctx, "jupyter-notebook-hello-world", "sudo touch /workspaces/jupyter-notebook-hello-world/DATA")
+			_, err = f.DevPodSSH(ctx, id, fmt.Sprintf("sudo touch /workspaces/%s/DATA", id))
 			framework.ExpectNoError(err)
-			_, err = f.DevPodSSH(ctx, "jupyter-notebook-hello-world", "sudo touch /ROOTFS")
+			_, err = f.DevPodSSH(ctx, id, "sudo touch /ROOTFS")
 			framework.ExpectNoError(err)
 
 			// reset
@@ -514,13 +517,13 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			framework.ExpectNoError(err)
 
 			// this should fail! because --reset should trigger a new git clone
-			_, err = f.DevPodSSH(ctx, "jupyter-notebook-hello-world", "ls /workspaces/jupyter-notebook-hello-world/DATA")
+			_, err = f.DevPodSSH(ctx, id, fmt.Sprintf("ls /workspaces/%s/DATA", id))
 			framework.ExpectError(err)
 			// this should fail! because --recreare should trigger a new build, so a new rootfs
-			_, err = f.DevPodSSH(ctx, "jupyter-notebook-hello-world", "ls /ROOTFS")
+			_, err = f.DevPodSSH(ctx, id, "ls /ROOTFS")
 			framework.ExpectError(err)
 
-			err = f.DevPodWorkspaceDelete(ctx, "jupyter-notebook-hello-world")
+			err = f.DevPodWorkspaceDelete(ctx, id)
 			framework.ExpectNoError(err)
 		})
 

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -441,11 +441,11 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			err = f.DevPodUp(ctx, "https://github.com/loft-sh/examples/@subpath:/devpod/jupyter-notebook-hello-world")
 			framework.ExpectNoError(err)
 
-			out, err := f.DevPodSSH(ctx, "subpath-devpod-jupyter-notebook-hello-world", "pwd")
+			out, err := f.DevPodSSH(ctx, "subpath--devpod-jupyter-notebook-hello-world", "pwd")
 			framework.ExpectNoError(err)
-			framework.ExpectEqual(out, "/workspaces/subpath-devpod-jupyter-notebook-hello-world\n", "should be subpath")
+			framework.ExpectEqual(out, "/workspaces/subpath--devpod-jupyter-notebook-hello-world\n", "should be subpath")
 
-			err = f.DevPodWorkspaceDelete(ctx, "subpath-devpod-jupyter-notebook-hello-world")
+			err = f.DevPodWorkspaceDelete(ctx, "subpath--devpod-jupyter-notebook-hello-world")
 			framework.ExpectNoError(err)
 		})
 

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -161,7 +161,7 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			err = f.DevPodProviderUse(ctx, "docker")
 			framework.ExpectNoError(err)
 
-			name := "vscode-remote-try-python-sha256-0c1547c"
+			name := "sha256-0c1547c"
 			ginkgo.DeferCleanup(f.DevPodWorkspaceDelete, context.Background(), name)
 
 			// Wait for devpod workspace to come online (deadline: 30s)
@@ -179,7 +179,7 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			err = f.DevPodProviderUse(ctx, "docker")
 			framework.ExpectNoError(err)
 
-			name := "devpod"
+			name := "pull-3-head"
 			ginkgo.DeferCleanup(f.DevPodWorkspaceDelete, context.Background(), name)
 
 			// Wait for devpod workspace to come online (deadline: 30s)

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -604,19 +604,29 @@ func ToID(str string) string {
 
 	str = prReferenceRegEx.ReplaceAllStringFunc(str, git.GetBranchNameForPR)
 
-	// get last element if we find a /
-	index := strings.LastIndex(str, "/")
-	if index != -1 {
-		str = str[index+1:]
-
-		// remove a potential tag / branch name
-		splitted := strings.Split(str, "@")
-		if len(splitted) == 2 && !branchRegEx.MatchString(splitted[1]) {
+	// Check if a branch name has been specified, if so use this for the ID
+	// If not, then parse the repo name as ID
+	splitted := strings.Split(str, "@")
+	if len(splitted) == 2 {
+		str = strings.TrimSuffix(splitted[1], ".git")
+		// Check if branch name matches expected regex
+		if !branchRegEx.MatchString(str) {
 			str = splitted[0]
 		}
+	} else {
+		// get last element if we find a /
+		index := strings.LastIndex(str, "/")
+		if index != -1 {
+			str = str[index+1:]
 
-		// remove .git if there is it
-		str = strings.TrimSuffix(str, ".git")
+			// remove a potential tag / branch name
+			if len(splitted) == 2 && !branchRegEx.MatchString(splitted[1]) {
+				str = splitted[0]
+			}
+
+			// remove .git if there is it
+			str = strings.TrimSuffix(str, ".git")
+		}
 	}
 
 	str = workspaceIDRegEx2.ReplaceAllString(workspaceIDRegEx1.ReplaceAllString(str, "-"), "")


### PR DESCRIPTION
This PR fixes the issue when starting a workspace using a branch identifier by first checking for `@` in the repo name and parsing the branch name appropriately.

I have tested the changes by first replicating the issue:

```
./devpod-cli up https://github.com/moderneinc/moderne-cluster-build-logs@dependabot/pip/Clustering/torch-2.2.0

➜  devpod git:(POD-755/fix-up-when-branch-contains-slash) ✗ ./devpod-cli list                                                                                             
  
                    NAME                  |                                               SOURCE                                               | MACHINE | PROVIDER |  IDE   | LAST USED |   AGE    
  ----------------------------------------+----------------------------------------------------------------------------------------------------+---------+----------+--------+-----------+----------
    torch-2-2-0                           | git:https://github.com/moderneinc/moderne-cluster-build-logs@dependabot/pip/Clustering/torch-2.2.0 |         | docker   | vscode | 19m51s    | 20m0s
```

Note the name of the workspace is not the branch name. Now running my branch...

```
./devpod-cli up https://github.com/moderneinc/moderne-cluster-build-logs@dependabot/pip/Clustering/torch-2.2.0

➜  devpod git:(POD-755/fix-up-when-branch-contains-slash) ✗ ./devpod-cli list                                                                                             
  
                    NAME                  |                                               SOURCE                                               | MACHINE | PROVIDER |  IDE   | LAST USED |   AGE    
  ----------------------------------------+----------------------------------------------------------------------------------------------------+---------+----------+--------+-----------+----------
    dependabot-pip-clustering-torch-2-2-0 | git:https://github.com/moderneinc/moderne-cluster-build-logs@dependabot/pip/Clustering/torch-2.2.0 |         | docker   | vscode | 2m53s     | 3m1s     
    torch-2-2-0                           | git:https://github.com/moderneinc/moderne-cluster-build-logs@dependabot/pip/Clustering/torch-2.2.0 |         | docker   | vscode | 19m51s    | 20m0s
```

Note the workspace name now reflects the branch name :)