### PR TITLE
fix(cli): ssh based auth with external key

### DIFF
--- a/cmd/helper/helper.go
+++ b/cmd/helper/helper.go
@@ -30,6 +30,7 @@ func NewHelperCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	helperCmd.AddCommand(NewCheckProviderUpdateCmd(globalFlags))
 	helperCmd.AddCommand(NewSSHClientCmd())
 	helperCmd.AddCommand(NewShellCmd())
+	helperCmd.AddCommand(NewSSHGitCloneCmd())
 	helperCmd.AddCommand(NewFleetServerCmd(globalFlags))
 	helperCmd.AddCommand(NewDockerCredentialsHelperCmd(globalFlags))
 	return helperCmd

--- a/cmd/helper/ssh_git_clone.go
+++ b/cmd/helper/ssh_git_clone.go
@@ -1,0 +1,105 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	command2 "github.com/loft-sh/devpod/pkg/command"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh"
+)
+
+type SSHGitClone struct {
+	KeyFile string
+	Port    string
+}
+
+func NewSSHGitCloneCmd() *cobra.Command {
+	cmd := &SSHGitClone{}
+	sshCmd := &cobra.Command{
+		Use:   "ssh-git-clone",
+		Short: "Drop-in ssh replacement in GIT_SSH_COMMAND",
+		RunE: func(_ *cobra.Command, args []string) error {
+			return cmd.Run(context.Background(), args)
+		},
+	}
+
+	sshCmd.Flags().StringVar(&cmd.KeyFile, "key-file", "", "SSH Key file to use")
+	sshCmd.Flags().StringVar(&cmd.Port, "port", "22", "SSH port to use, defaults to 22")
+	_ = sshCmd.MarkFlagRequired("key-file")
+	return sshCmd
+}
+
+func (cmd *SSHGitClone) Run(ctx context.Context, args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("expected args in format: {user}@{host} {commands...}, received \"%s\"", strings.Join(args, " "))
+	}
+	host := args[0]
+	sshCmdArgs := args[1:]
+	if len(host) == 0 || len(sshCmdArgs) == 0 {
+		return fmt.Errorf("unexpected input: host: %s, args: %s", host, strings.Join(sshCmdArgs, " "))
+	}
+
+	user, addr, err := parseSSHHost(host)
+	if err != nil {
+		return err
+	}
+
+	sshConfig, err := getConfig(user, cmd.KeyFile)
+	if err != nil {
+		return err
+	}
+
+	sshClient, err := ssh.Dial("tcp", net.JoinHostPort(addr, cmd.Port), sshConfig)
+	if err != nil {
+		return err
+	}
+	defer sshClient.Close()
+
+	sess, err := sshClient.NewSession()
+	if err != nil {
+		return err
+	}
+	defer sess.Close()
+
+	sess.Stdin = os.Stdin
+	sess.Stdout = os.Stdout
+	sess.Stderr = os.Stderr
+	err = sess.Run(command2.Quote(sshCmdArgs))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getConfig(userName string, keyFilePath string) (*ssh.ClientConfig, error) {
+	out, err := os.ReadFile(keyFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("read private ssh key: %w", err)
+	}
+
+	signer, err := ssh.ParsePrivateKey(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+
+	return &ssh.ClientConfig{
+		User: userName,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}, nil
+}
+
+func parseSSHHost(host string) (string, string, error) {
+	s := strings.SplitN(host, "@", 2)
+	if len(s) != 2 {
+		return "", "", fmt.Errorf("split host: %s", host)
+	}
+
+	return s[0], s[1], nil
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -140,7 +140,7 @@ func (l *LifecycleHook) UnmarshalJSON(data []byte) error {
 type StrBool string
 
 // UnmarshalJSON parses fields that may be numbers or booleans.
-func (f *StrBool) UnmarshalJSON(data []byte) error {
+func (s *StrBool) UnmarshalJSON(data []byte) error {
 	var jsonObj interface{}
 	err := json.Unmarshal(data, &jsonObj)
 	if err != nil {
@@ -148,13 +148,21 @@ func (f *StrBool) UnmarshalJSON(data []byte) error {
 	}
 	switch obj := jsonObj.(type) {
 	case string:
-		*f = StrBool(obj)
+		*s = StrBool(obj)
 		return nil
 	case bool:
-		*f = StrBool(strconv.FormatBool(obj))
+		*s = StrBool(strconv.FormatBool(obj))
 		return nil
 	}
 	return ErrUnsupportedType
+}
+
+func (s *StrBool) Bool() (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+
+	return strconv.ParseBool(string(*s))
 }
 
 type OptionEnum struct {


### PR DESCRIPTION
proxy git ssh traffic through our internal client because openssh might not
be installed in the target environment.
If we detect an external SSH key, we pass the GIT_SSH_COMMAND to git,
pointing to the new `devpod helper ssh-git-clone` command.
