### PR TITLE
POD-758: Allow user to specify fleet version

### DIFF
--- a/pkg/ide/fleet/fleet.go
+++ b/pkg/ide/fleet/fleet.go
@@ -142,6 +142,8 @@ func (o *FleetServer) Start(binaryPath, location, projectDir string) error {
 			)
 		}
 
+		o.log.Infof("version set to %s using command %s \n", version, runCommand)
+
 		args := []string{}
 		if o.userName != "" {
 			args = append(args, "su", o.userName, "-c", runCommand)

--- a/pkg/ide/fleet/fleet.go
+++ b/pkg/ide/fleet/fleet.go
@@ -138,11 +138,9 @@ func (o *FleetServer) Start(binaryPath, location, projectDir string) error {
 		} else {
 			runCommand = fmt.Sprintf(
 				"%s launch workspace --workspace-version %s -- --projectDir '%s' --cache-path '%s' --auth=accept-everyone --publish --enableSmartMode",
-				version, binaryPath, projectDir, location,
+				binaryPath, version, projectDir, location,
 			)
 		}
-
-		o.log.Infof("version set to %s using command %s \n", version, runCommand)
 
 		args := []string{}
 		if o.userName != "" {


### PR DESCRIPTION
This PR introduces an additional IDE option for fleet to indicate which version to install.

```
➜  devpod git:(POD-758/specify-fleet-version) ✗ ./devpod-cli ide options fleet
  
         NAME      |          DESCRIPTION           |                                                   DEFAULT                                                    | VALUE  
  -----------------+--------------------------------+--------------------------------------------------------------------------------------------------------------+--------
    DOWNLOAD_AMD64 | The download url for the amd64 | https://download.jetbrains.com/product?code=FLL&release.type=preview&release.type=eap&platform=linux_x64     |        
                   | install script                 |                                                                                                              |        
    DOWNLOAD_ARM64 | The download url for the arm64 | https://download.jetbrains.com/product?code=FLL&release.type=preview&release.type=eap&platform=linux_aarch64 |        
                   | install script                 |                                                                                                              |        
    VERSION        | The version of fleet to        | latest                                                                                                       | 1.37.84       
                   | install                        |                                                                                                              |        
```

We then check this value and if latest is not specified we use the CLI option of fleet launcher to indicate the version of fleet to install.

Below is a screen shot when I launched `example/simple` with the fleet version specified

![Screenshot from 2024-08-12 09-37-24](https://github.com/user-attachments/assets/23b8b1eb-60e5-436b-8404-2ae5dffdeb5d)
