### PR TITLE
POD-771: Check response code is successful when installing intilliJ based IDE

### DIFF
--- a/pkg/ide/jetbrains/generic.go
+++ b/pkg/ide/jetbrains/generic.go
@@ -3,6 +3,7 @@ package jetbrains
 import (
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -177,6 +178,10 @@ func (o *GenericJetBrainsServer) download(targetFolder string, log log.Logger) (
 		return "", errors.Wrap(err, "download binary")
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", errors.Wrapf(err, "download binary returned status code %d", resp.StatusCode)
+	}
 
 	stat, err := os.Stat(targetPath)
 	if err == nil && stat.Size() == resp.ContentLength {


### PR DESCRIPTION
This PR adds a check to ensure intilliJ returned a 200 or 201 response code when downloading the IDE binary. This allows us to provide better error handling by providing the status code in the logs. This could be caused by using a bad version string to build thew download URL.

This PR was tested using `./devpod-cli up --ide intellij examples/simple` and ensuring the intillJ IDE was installed and launched.