### PR TITLE
POD-769: Check build target exists in Dockerfile

### DIFF
--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -233,9 +233,11 @@ func (r *runner) getImageBuildInfoFromDockerfile(substitutionContext *config.Sub
 	}
 
 	// Check that the build target specified in the devcontainer.json exists in the Dockerfile
-	_, ok := parsedDockerfile.StagesByTarget[target]
-	if !ok {
-		return nil, fmt.Errorf("build target does not exist")
+	if target != "" && parsedDockerfile.StagesByTarget != nil {
+		_, ok := parsedDockerfile.StagesByTarget[target]
+		if !ok {
+			return nil, fmt.Errorf("build target does not exist")
+		}
 	}
 
 	baseImage := parsedDockerfile.FindBaseImage(buildArgs, target)

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -235,7 +235,7 @@ func (r *runner) getImageBuildInfoFromDockerfile(substitutionContext *config.Sub
 	// Check that the build target specified in the devcontainer.json exists in the Dockerfile
 	_, ok := parsedDockerfile.StagesByTarget[target]
 	if !ok {
-		return nil, errors.Wrap(err, "build target does not exist")
+		return nil, fmt.Errorf("build target does not exist")
 	}
 
 	baseImage := parsedDockerfile.FindBaseImage(buildArgs, target)

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -232,6 +232,12 @@ func (r *runner) getImageBuildInfoFromDockerfile(substitutionContext *config.Sub
 		return nil, errors.Wrap(err, "parse dockerfile")
 	}
 
+	// Check that the build target specified in the devcontainer.json exists in the Dockerfile
+	_, ok := parsedDockerfile.StagesByTarget[target]
+	if !ok {
+		return nil, errors.Wrap(err, "build target does not exist")
+	}
+
 	baseImage := parsedDockerfile.FindBaseImage(buildArgs, target)
 	if baseImage == "" {
 		return nil, fmt.Errorf("find base image %s", target)


### PR DESCRIPTION
This PR fixes an issue a user had due to them specifying a build target in devcontainer.json that was not present in the Dockerfile. This PR solves the issue by validating the Dockerfile before deploying.