### PR TITLE
fix(pro): delete ownded workspace

### DIFF
--- a/cmd/pro/provider/helper.go
+++ b/cmd/pro/provider/helper.go
@@ -139,7 +139,7 @@ func DialWorkspace(baseClient client.Client, workspace *managementv1.DevPodWorks
 		if response != nil {
 			out, _ := io.ReadAll(response.Body)
 			headers, _ := json.Marshal(response.Header)
-			return nil, fmt.Errorf("error dialing websocket %s (code %d): headers - %s, response - %s, error - %w", loftURL, response.StatusCode, string(headers), string(out), err)
+			return nil, fmt.Errorf("%s: error dialing websocket %s (code %d): headers - %s, error - %w", string(out), loftURL, response.StatusCode, string(headers), err)
 		}
 
 		return nil, fmt.Errorf("error dialing websocket %s: %w", loftURL, err)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -996,7 +996,7 @@ func setupLoftPlatformAccess(context, provider, user string, client client2.Base
 
 	command := fmt.Sprintf("%v agent container setup-loft-platform-access --context %v --provider %v --port %v", agent.ContainerDevPodHelperLocation, context, provider, port)
 
-	log.Infof("Executing command -> %v", command)
+	log.Debugf("Executing command -> %v", command)
 	err = exec.Command(
 		execPath,
 		"ssh",


### PR DESCRIPTION
Pro provider attempts to delete the CRD instead of calling the
workspace instances `/delete` endpoint on the runner.
This allows us to hook into the ownership mechanism without granting all
project users access to the `devpodworkspaceinstances/delete`
subresource.
In effect this allows all project users to delete their own workspaces
but not others. Admins can still delete all workspaces
