### PR TITLE
POD-819: Add --gpus=all if host requirments contain GPU

### DIFF
--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -325,6 +326,14 @@ func (d *dockerDriver) RunDockerDevContainer(
 	}
 
 	// runArgs
+	// check if we need to add --gpus=all to the run args based on the dev container's host requirments
+	usesGpu, err := parsedConfig.HostRequirements.GPU.Bool()
+	if err != nil && usesGpu {
+		// check if the user manually add --gpus=all, if not then add it
+		if !slices.Contains(parsedConfig.RunArgs, "--gpus=all") {
+			args = append(args, "--gpus=all")
+		}
+	}
 	args = append(args, parsedConfig.RunArgs...)
 
 	// run detached

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -327,13 +327,16 @@ func (d *dockerDriver) RunDockerDevContainer(
 
 	// runArgs
 	// check if we need to add --gpus=all to the run args based on the dev container's host requirments
-	usesGpu, err := parsedConfig.HostRequirements.GPU.Bool()
-	if err != nil && usesGpu {
-		// check if the user manually add --gpus=all, if not then add it
-		if !slices.Contains(parsedConfig.RunArgs, "--gpus=all") {
-			args = append(args, "--gpus=all")
+	if parsedConfig.HostRequirements != nil {
+		usesGpu, err := parsedConfig.HostRequirements.GPU.Bool()
+		if err != nil && usesGpu {
+			// check if the user manually add --gpus=all, if not then add it
+			if !slices.Contains(parsedConfig.RunArgs, "--gpus=all") {
+				args = append(args, "--gpus=all")
+			}
 		}
 	}
+
 	args = append(args, parsedConfig.RunArgs...)
 
 	// run detached


### PR DESCRIPTION
This PR addresses the issue outlined in https://github.com/loft-sh/devpod/issues/1197

Effectively this PR automatically adds the appropriate `--gpus-all` flag to the run args since this is the defined behaviour by the dev container spec