### PR TITLE
fix/POD 837 remove fallback cloning

### DIFF
--- a/cmd/agent/workspace/install_dotfiles.go
+++ b/cmd/agent/workspace/install_dotfiles.go
@@ -51,8 +51,8 @@ func (cmd *InstallDotfilesCmd) Run(ctx context.Context) error {
 		logger.Infof("Cloning dotfiles %s", cmd.Repository)
 
 		gitInfo := git.NormalizeRepositoryGitInfo(cmd.Repository)
-		err = git.CloneRepository(ctx, gitInfo, targetDir, "", false, nil, logger.Writer(logrus.DebugLevel, false), logger)
-		if err != nil {
+
+		if err := git.CloneRepository(ctx, gitInfo, targetDir, "", nil, logger); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/devcontainer/helpers.go
+++ b/pkg/devcontainer/helpers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/loft-sh/devpod/pkg/git"
 	"github.com/loft-sh/devpod/pkg/image"
 	"github.com/loft-sh/log"
-	"github.com/sirupsen/logrus"
 )
 
 type GetWorkspaceConfigResult struct {
@@ -90,7 +89,7 @@ func FindFilesInGitRepo(ctx context.Context, gitRepository, gitPRReference, gitB
 
 	gitInfo := git.NewGitInfo(gitRepository, gitBranch, gitCommit, gitPRReference, gitSubDir)
 	log.Debugf("Cloning git repository into %s", tmpDirPath)
-	err := git.CloneRepository(ctx, gitInfo, tmpDirPath, "", true, git.NewCloner(git.ShallowCloneStrategy), log.Writer(logrus.DebugLevel, false), log)
+	err := git.CloneRepository(ctx, gitInfo, tmpDirPath, "", git.NewCloner(git.BareCloneStrategy), log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -1,10 +1,13 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 
+	"github.com/loft-sh/log"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 
@@ -15,10 +18,11 @@ const (
 	BloblessCloneStrategy CloneStrategy = "blobless"
 	TreelessCloneStrategy CloneStrategy = "treeless"
 	ShallowCloneStrategy  CloneStrategy = "shallow"
+	BareCloneStrategy     CloneStrategy = "bare"
 )
 
 type Cloner interface {
-	Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, stdout, stderr io.Writer) error
+	Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, log log.Logger) error
 }
 
 func NewCloner(strategy CloneStrategy) Cloner {
@@ -29,6 +33,8 @@ func NewCloner(strategy CloneStrategy) Cloner {
 		return &treelessClone{}
 	case ShallowCloneStrategy:
 		return &shallowClone{}
+	case BareCloneStrategy:
+		return &bareClone{}
 	case FullCloneStrategy:
 		return &fullClone{}
 	default:
@@ -43,7 +49,8 @@ func (s *CloneStrategy) Set(v string) error {
 	case string(FullCloneStrategy),
 		string(BloblessCloneStrategy),
 		string(TreelessCloneStrategy),
-		string(ShallowCloneStrategy):
+		string(ShallowCloneStrategy),
+		string(BareCloneStrategy):
 		{
 			*s = CloneStrategy(v)
 			return nil
@@ -65,51 +72,81 @@ type fullClone struct{}
 
 var _ Cloner = &fullClone{}
 
-func (c *fullClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, stdout, stderr io.Writer) error {
+func (c *fullClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, log log.Logger) error {
 	args := []string{"clone"}
 	args = append(args, extraArgs...)
 	args = append(args, repository, targetDir)
-	return run(ctx, args, extraEnv, stdout, stderr)
+	return run(ctx, args, extraEnv, log)
 }
 
 type bloblessClone struct{}
 
 var _ Cloner = &bloblessClone{}
 
-func (c *bloblessClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, stdout, stderr io.Writer) error {
+func (c *bloblessClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, log log.Logger) error {
 	args := []string{"clone", "--filter=blob:none"}
 	args = append(args, extraArgs...)
 	args = append(args, repository, targetDir)
-	return run(ctx, args, extraEnv, stdout, stderr)
+	return run(ctx, args, extraEnv, log)
 }
 
 type treelessClone struct{}
 
 var _ Cloner = treelessClone{}
 
-func (c treelessClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, stdout, stderr io.Writer) error {
+func (c treelessClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, log log.Logger) error {
 	args := []string{"clone", "--filter=tree:0"}
 	args = append(args, extraArgs...)
 	args = append(args, repository, targetDir)
-	return run(ctx, args, extraEnv, stdout, stderr)
+	return run(ctx, args, extraEnv, log)
 }
 
 type shallowClone struct{}
 
 var _ Cloner = shallowClone{}
 
-func (c shallowClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, stdout, stderr io.Writer) error {
+func (c shallowClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, log log.Logger) error {
 	args := []string{"clone", "--depth=1"}
 	args = append(args, extraArgs...)
 	args = append(args, repository, targetDir)
-	return run(ctx, args, extraEnv, stdout, stderr)
+	return run(ctx, args, extraEnv, log)
 }
 
-func run(ctx context.Context, args []string, extraEnv []string, stdout, stderr io.Writer) error {
+type bareClone struct{}
+
+var _ Cloner = bareClone{}
+
+func (c bareClone) Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, log log.Logger) error {
+	args := []string{"clone", "bare", "--depth=1"}
+	args = append(args, extraArgs...)
+	args = append(args, repository, targetDir)
+	return run(ctx, args, extraEnv, log)
+}
+
+func run(ctx context.Context, args []string, extraEnv []string, log log.Logger) error {
+	var buf bytes.Buffer
+
+	args = append(args, "--progress")
+
 	gitCommand := CommandContext(ctx, args...)
-	gitCommand.Stdout = stdout
-	gitCommand.Stderr = stderr
+	gitCommand.Stdout = &buf
+	gitCommand.Stderr = &buf
 	gitCommand.Env = append(gitCommand.Env, extraEnv...)
 
-	return gitCommand.Run()
+	// git always prints prograss output to stderr,
+	// we need to check the exit code to decide where the logs should go
+	if err := gitCommand.Run(); err != nil {
+		// report as error
+		if _, err2 := io.Copy(log.Writer(logrus.ErrorLevel, false), &buf); err2 != nil {
+			return err2
+		}
+		return err
+	}
+
+	// report as debug
+	if _, err := io.Copy(log.Writer(logrus.DebugLevel, false), &buf); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"context"
-	"io"
+	"fmt"
 	"os"
 	"os/exec"
 	"regexp"
@@ -11,7 +11,7 @@ import (
 
 	"github.com/loft-sh/devpod/pkg/command"
 	"github.com/loft-sh/log"
-	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -114,63 +114,80 @@ func NormalizeRepositoryGitInfo(str string) *GitInfo {
 	return NewGitInfo(repository, branch, commit, pr, subpath)
 }
 
-func CloneRepository(ctx context.Context, gitInfo *GitInfo, targetDir string, helper string, bare bool, cloner Cloner, writer io.Writer, log log.Logger) error {
-	return CloneRepositoryWithEnv(ctx, gitInfo, []string{}, targetDir, helper, bare, cloner, writer, log)
+func CloneRepository(ctx context.Context, gitInfo *GitInfo, targetDir string, helper string, cloner Cloner, log log.Logger) error {
+	return CloneRepositoryWithEnv(ctx, gitInfo, []string{}, targetDir, helper, cloner, log)
 }
 
-func CloneRepositoryWithEnv(ctx context.Context, gitInfo *GitInfo, extraEnv []string, targetDir string, helper string, bare bool, cloner Cloner, writer io.Writer, log log.Logger) error {
+func CloneRepositoryWithEnv(ctx context.Context, gitInfo *GitInfo, extraEnv []string, targetDir string, helper string, cloner Cloner, log log.Logger) error {
 	if cloner == nil {
 		cloner = NewCloner(FullCloneStrategy)
 	}
 
 	extraArgs := []string{}
-	if bare && gitInfo.Commit == "" {
-		extraArgs = append(extraArgs, "--bare", "--depth=1")
-	}
 	if helper != "" {
 		extraArgs = append(extraArgs, "--config", "credential.helper="+helper)
 	}
+
 	if gitInfo.Branch != "" {
 		extraArgs = append(extraArgs, "--branch", gitInfo.Branch)
 	}
 
-	err := cloner.Clone(ctx, gitInfo.Repository, targetDir, extraArgs, extraEnv, writer, writer)
-	if err != nil {
-		return errors.Wrap(err, "error cloning repository")
+	if err := cloner.Clone(ctx, gitInfo.Repository, targetDir, extraArgs, extraEnv, log); err != nil {
+		return err
 	}
 
 	if gitInfo.PR != "" {
-		log.Debugf("Fetching pull request : %s", gitInfo.PR)
-
-		prBranch := GetBranchNameForPR(gitInfo.PR)
-
-		// git fetch origin pull/996/head:PR996
-		fetchArgs := []string{"fetch", "origin", gitInfo.PR + ":" + prBranch}
-		fetchCmd := CommandContext(ctx, fetchArgs...)
-		fetchCmd.Dir = targetDir
-		err = fetchCmd.Run()
-		if err != nil {
-			return errors.Wrap(err, "error fetching pull request reference")
-		}
-
-		// git switch PR996
-		switchArgs := []string{"switch", prBranch}
-		switchCmd := CommandContext(ctx, switchArgs...)
-		switchCmd.Dir = targetDir
-		err = switchCmd.Run()
-		if err != nil {
-			return errors.Wrap(err, "error switching to the branch")
-		}
-	} else if gitInfo.Commit != "" {
-		args := []string{"reset", "--hard", gitInfo.Commit}
-		gitCommand := CommandContext(ctx, args...)
-		gitCommand.Dir = targetDir
-		gitCommand.Stdout = writer
-		gitCommand.Stderr = writer
-		err := gitCommand.Run()
-		if err != nil {
-			return errors.Wrap(err, "error resetting head to commit")
-		}
+		return checkoutPR(ctx, gitInfo, targetDir, log)
 	}
+
+	if gitInfo.Commit != "" {
+		return checkoutCommit(ctx, gitInfo, targetDir, log)
+	}
+
+	return nil
+}
+
+func checkoutPR(ctx context.Context, gitInfo *GitInfo, targetDir string, log log.Logger) error {
+	log.Debugf("Fetching pull request : %s", gitInfo.PR)
+
+	prBranch := GetBranchNameForPR(gitInfo.PR)
+
+	// Try to fetch the pull request by
+	// checking out the reference GitHub set up for it. Afterwards, switch to it.
+	// See [this doc](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally#modifying-an-inactive-pull-request-locally)
+	// Command args: `git fetch origin pull/996/head:PR996`
+	fetchArgs := []string{"fetch", "origin", gitInfo.PR + ":" + prBranch}
+	fetchCmd := CommandContext(ctx, fetchArgs...)
+	fetchCmd.Dir = targetDir
+	if err := fetchCmd.Run(); err != nil {
+		return fmt.Errorf("fetch pull request reference: %w", err)
+	}
+
+	// git switch PR996
+	switchArgs := []string{"switch", prBranch}
+	switchCmd := CommandContext(ctx, switchArgs...)
+	switchCmd.Dir = targetDir
+	if err := switchCmd.Run(); err != nil {
+		return fmt.Errorf("switch to branch: %w", err)
+	}
+
+	return nil
+}
+
+func checkoutCommit(ctx context.Context, gitInfo *GitInfo, targetDir string, log log.Logger) error {
+	stdout := log.Writer(logrus.InfoLevel, false)
+	stderr := log.Writer(logrus.ErrorLevel, false)
+	defer stdout.Close()
+	defer stderr.Close()
+
+	args := []string{"reset", "--hard", gitInfo.Commit}
+	gitCommand := CommandContext(ctx, args...)
+	gitCommand.Dir = targetDir
+	gitCommand.Stdout = stdout
+	gitCommand.Stderr = stderr
+	if err := gitCommand.Run(); err != nil {
+		return fmt.Errorf("reset head to commit: %w", err)
+	}
+
 	return nil
 }

--- a/pkg/git/install.go
+++ b/pkg/git/install.go
@@ -1,0 +1,67 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/loft-sh/devpod/pkg/command"
+	"github.com/loft-sh/log"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func InstallBinary(log log.Logger) error {
+	writer := log.Writer(logrus.InfoLevel, false)
+	errwriter := log.Writer(logrus.ErrorLevel, false)
+	defer writer.Close()
+	defer errwriter.Close()
+
+	// try to install git via apt / apk
+	if !command.Exists("apt") && !command.Exists("apk") {
+		// TODO: use golang git implementation
+		return fmt.Errorf("couldn't find a package manager to install git")
+	}
+
+	if command.Exists("apt") {
+		log.Infof("Git command is missing, try to install git with apt...")
+		cmd := exec.Command("apt", "update")
+		cmd.Stdout = writer
+		cmd.Stderr = errwriter
+		err := cmd.Run()
+		if err != nil {
+			return errors.Wrap(err, "run apt update")
+		}
+		cmd = exec.Command("apt", "-y", "install", "git")
+		cmd.Stdout = writer
+		cmd.Stderr = errwriter
+		err = cmd.Run()
+		if err != nil {
+			return errors.Wrap(err, "run apt install git -y")
+		}
+	} else if command.Exists("apk") {
+		log.Infof("Git command is missing, try to install git with apk...")
+		cmd := exec.Command("apk", "update")
+		cmd.Stdout = writer
+		cmd.Stderr = errwriter
+		err := cmd.Run()
+		if err != nil {
+			return errors.Wrap(err, "run apk update")
+		}
+		cmd = exec.Command("apk", "add", "git")
+		cmd.Stdout = writer
+		cmd.Stderr = errwriter
+		err = cmd.Run()
+		if err != nil {
+			return errors.Wrap(err, "run apk add git")
+		}
+	}
+
+	// is git available now?
+	if !command.Exists("git") {
+		return fmt.Errorf("couldn't install git")
+	}
+
+	log.Donef("Successfully installed git")
+
+	return nil
+}

--- a/pkg/gitcredentials/gitcredentials.go
+++ b/pkg/gitcredentials/gitcredentials.go
@@ -282,3 +282,8 @@ func getGlobalGitConfigPath(userName string) (string, error) {
 
 	return filepath.Join(home, ".gitconfig"), nil
 }
+
+// GetLocalGitConfigPath resolves the local git config for the specified repository path
+func GetLocalGitConfigPath(repoPath string) string {
+	return filepath.Join(repoPath, ".git", "config")
+}


### PR DESCRIPTION
- **fix(cli): only setup platform access if we're using pro provider to create workspace**

- **fix(cli): remove local clone fallback**
Removes the current behaviour of falling back to a local clone and
upload to VM/Pod afterwards. Over the course of the last year we've
found it is more confusing than it helps.
Instead, this PR improves the logs when cloning on the remote fails to
allow users to address the root cause better.
