### PR TITLE
Use fullDownloadURL for clarity in downloadAgentLocally function

### DIFF
--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -197,7 +197,7 @@ func downloadAgentLocally(tryDownloadURL, targetArch string, log log.Logger) (st
 	}
 
 	fullDownloadURL := tryDownloadURL + "/devpod-linux-" + targetArch
-	log.Infof("Attempting to download DevPod agent from: %s", fullDownloadURL)
+	log.Debugf("Attempting to download DevPod agent from: %s", fullDownloadURL)
 
 	resp, err := devpodhttp.GetHTTPClient().Get(fullDownloadURL)
 	if err != nil {

--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -196,7 +196,10 @@ func downloadAgentLocally(tryDownloadURL, targetArch string, log log.Logger) (st
 		return agentPath, nil
 	}
 
-	resp, err := devpodhttp.GetHTTPClient().Get(tryDownloadURL + "/devpod-linux-" + targetArch)
+	fullDownloadURL := tryDownloadURL + "/devpod-linux-" + targetArch
+	log.Infof("Attempting to download DevPod agent from: %s", fullDownloadURL)
+
+	resp, err := devpodhttp.GetHTTPClient().Get(fullDownloadURL)
 	if err != nil {
 		return "", errors.Wrap(err, "download devpod")
 	}
@@ -216,7 +219,7 @@ func downloadAgentLocally(tryDownloadURL, targetArch string, log log.Logger) (st
 	_, err = io.Copy(file, resp.Body)
 	if err != nil {
 		_ = os.Remove(agentPath)
-		return "", errors.Wrap(err, "download devpod")
+		return "", errors.Wrapf(err, "failed to download devpod from URL: %s", fullDownloadURL)
 	}
 
 	return agentPath, nil


### PR DESCRIPTION
**Improvement: Enhanced Logging for Download URLs**

This PR improves the logging of the full download URL in the `downloadAgentLocally` function, addressing potential issues where incomplete or incorrect URLs lead to errors such as 404.

This change follows up on Issue #1240 where it was discussed that the current logging might not be sufficient for diagnosing certain network-related issues.

Closes #1240.
