### PR TITLE
POD-821 | Support `file://` ulr pattern when normalizing repo URL

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -23,7 +23,7 @@ const (
 // WARN: Make sure this matches the regex in /desktop/src/views/Workspaces/CreateWorkspace/CreateWorkspaceInput.tsx!
 var (
 	// Updated regex pattern to support SSH-style Git URLs
-	repoBaseRegEx    = `((?:(?:https?|git|ssh):\/\/)?(?:[^@\/\n]+@)?(?:[^:\/\n]+)(?:[:\/][^\/\n]+)+(?:\.git)?)`
+	repoBaseRegEx    = `((?:(?:https?|git|ssh|file):\/\/)?\/?(?:[^@\/\n]+@)?(?:[^:\/\n]+)(?:[:\/][^\/\n]+)+(?:\.git)?)`
 	branchRegEx      = regexp.MustCompile(`^` + repoBaseRegEx + `@([a-zA-Z0-9\./\-\_]+)$`)
 	commitRegEx      = regexp.MustCompile(`^` + repoBaseRegEx + regexp.QuoteMeta(CommitDelimiter) + `([a-zA-Z0-9]+)$`)
 	prReferenceRegEx = regexp.MustCompile(`^` + repoBaseRegEx + `@(` + PullRequestReference + `)$`)
@@ -31,7 +31,11 @@ var (
 )
 
 func NormalizeRepository(str string) (string, string, string, string, string) {
-	if !strings.HasPrefix(str, "ssh://") && !strings.HasPrefix(str, "git@") && !strings.HasPrefix(str, "http://") && !strings.HasPrefix(str, "https://") {
+	if !strings.HasPrefix(str, "ssh://") &&
+		!strings.HasPrefix(str, "git@") &&
+		!strings.HasPrefix(str, "http://") &&
+		!strings.HasPrefix(str, "https://") &&
+		!strings.HasPrefix(str, "file://") {
 		str = "https://" + str
 	}
 

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -191,6 +191,38 @@ func TestNormalizeRepository(t *testing.T) {
 			expectedCommit:      "",
 			expectedSubpath:     "",
 		},
+		{
+			in:                  "file:///workspace/projects/project",
+			expectedRepo:        "file:///workspace/projects/project",
+			expectedPRReference: "",
+			expectedBranch:      "",
+			expectedCommit:      "",
+			expectedSubpath:     "",
+		},
+		{
+			in:                  "file:///workspace/projects/project@dev",
+			expectedRepo:        "file:///workspace/projects/project",
+			expectedPRReference: "",
+			expectedBranch:      "dev",
+			expectedCommit:      "",
+			expectedSubpath:     "",
+		},
+		{
+			in:                  "file:///workspace/projects/project@sha256:905ffb0",
+			expectedRepo:        "file:///workspace/projects/project",
+			expectedPRReference: "",
+			expectedBranch:      "",
+			expectedCommit:      "905ffb0",
+			expectedSubpath:     "",
+		},
+		{
+			in:                  "file:///workspace/projects/project@subpath:/test/path",
+			expectedRepo:        "file:///workspace/projects/project",
+			expectedPRReference: "",
+			expectedBranch:      "",
+			expectedCommit:      "",
+			expectedSubpath:     "/test/path",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Part of POD-821

Git supports running git pull on local repositories using file:///path/to/repo url pattern