### PR TITLE
fix(cli): add --devpod-home to ssh config

### DIFF
--- a/pkg/ssh/config_test.go
+++ b/pkg/ssh/config_test.go
@@ -10,29 +10,31 @@ import (
 
 func TestAddHostSection(t *testing.T) {
 	tests := []struct {
-		name      string
-		config    string
-		execPath  string
-		host      string
-		user      string
-		context   string
-		workspace string
-		workdir   string
-		command   string
-		gpgagent  bool
-		expected  string
+		name       string
+		config     string
+		execPath   string
+		host       string
+		user       string
+		context    string
+		workspace  string
+		workdir    string
+		command    string
+		gpgagent   bool
+		devPodHome string
+		expected   string
 	}{
 		{
-			name:      "Basic host addition",
-			config:    "",
-			execPath:  "/path/to/exec",
-			host:      "testhost",
-			user:      "testuser",
-			context:   "testcontext",
-			workspace: "testworkspace",
-			workdir:   "",
-			command:   "",
-			gpgagent:  false,
+			name:       "Basic host addition",
+			config:     "",
+			execPath:   "/path/to/exec",
+			host:       "testhost",
+			user:       "testuser",
+			context:    "testcontext",
+			workspace:  "testworkspace",
+			workdir:    "",
+			command:    "",
+			gpgagent:   false,
+			devPodHome: "",
 			expected: `# DevPod Start testhost
 Host testhost
   ForwardAgent yes
@@ -45,16 +47,17 @@ Host testhost
 # DevPod End testhost`,
 		},
 		{
-			name:      "Host addition with workdir",
-			config:    "",
-			execPath:  "/path/to/exec",
-			host:      "testhost",
-			user:      "testuser",
-			context:   "testcontext",
-			workspace: "testworkspace",
-			workdir:   "/path/to/workdir",
-			command:   "",
-			gpgagent:  false,
+			name:       "Basic host addition with DEVPOD_HOME",
+			config:     "",
+			execPath:   "/path/to/exec",
+			host:       "testhost",
+			user:       "testuser",
+			context:    "testcontext",
+			workspace:  "testworkspace",
+			workdir:    "",
+			command:    "",
+			gpgagent:   false,
+			devPodHome: "C:\\\\White Space\\devpod\\test",
 			expected: `# DevPod Start testhost
 Host testhost
   ForwardAgent yes
@@ -62,21 +65,22 @@ Host testhost
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   HostKeyAlgorithms rsa-sha2-256,rsa-sha2-512,ssh-rsa
-  ProxyCommand "/path/to/exec" ssh --stdio --context testcontext --user testuser testworkspace --workdir /path/to/workdir
+  ProxyCommand "/path/to/exec" ssh --stdio --context testcontext --user testuser testworkspace --devpod-home "C:\\White Space\devpod\test"
   User testuser
 # DevPod End testhost`,
 		},
 		{
-			name:      "Host addition with gpg agent",
-			config:    "",
-			execPath:  "/path/to/exec",
-			host:      "testhost",
-			user:      "testuser",
-			context:   "testcontext",
-			workspace: "testworkspace",
-			workdir:   "",
-			command:   "",
-			gpgagent:  true,
+			name:       "Host addition with workdir",
+			config:     "",
+			execPath:   "/path/to/exec",
+			host:       "testhost",
+			user:       "testuser",
+			context:    "testcontext",
+			workspace:  "testworkspace",
+			workdir:    "/path/to/workdir",
+			command:    "",
+			gpgagent:   false,
+			devPodHome: "",
 			expected: `# DevPod Start testhost
 Host testhost
   ForwardAgent yes
@@ -84,21 +88,45 @@ Host testhost
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   HostKeyAlgorithms rsa-sha2-256,rsa-sha2-512,ssh-rsa
-  ProxyCommand "/path/to/exec" ssh --gpg-agent-forwarding --stdio --context testcontext --user testuser testworkspace
+  ProxyCommand "/path/to/exec" ssh --stdio --context testcontext --user testuser testworkspace --workdir "/path/to/workdir"
   User testuser
 # DevPod End testhost`,
 		},
 		{
-			name:      "Host addition with custom command",
-			config:    "",
-			execPath:  "/path/to/exec",
-			host:      "testhost",
-			user:      "testuser",
-			context:   "testcontext",
-			workspace: "testworkspace",
-			workdir:   "",
-			command:   "ssh -W %h:%p bastion",
-			gpgagent:  false,
+			name:       "Host addition with gpg agent",
+			config:     "",
+			execPath:   "/path/to/exec",
+			host:       "testhost",
+			user:       "testuser",
+			context:    "testcontext",
+			workspace:  "testworkspace",
+			workdir:    "",
+			command:    "",
+			gpgagent:   true,
+			devPodHome: "",
+			expected: `# DevPod Start testhost
+Host testhost
+  ForwardAgent yes
+  LogLevel error
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  HostKeyAlgorithms rsa-sha2-256,rsa-sha2-512,ssh-rsa
+  ProxyCommand "/path/to/exec" ssh --stdio --context testcontext --user testuser testworkspace --gpg-agent-forwarding
+  User testuser
+# DevPod End testhost`,
+		},
+		{
+			name:       "Host addition with custom command",
+			config:     "",
+			execPath:   "/path/to/exec",
+			host:       "testhost",
+			user:       "testuser",
+			context:    "testcontext",
+			workspace:  "testworkspace",
+			workdir:    "",
+			command:    "ssh -W %h:%p bastion",
+			gpgagent:   false,
+			devPodHome: "",
 			expected: `# DevPod Start testhost
 Host testhost
   ForwardAgent yes
@@ -114,14 +142,15 @@ Host testhost
 			name: "Host addition to existing config",
 			config: `Host existinghost
   User existinguser`,
-			execPath:  "/path/to/exec",
-			host:      "testhost",
-			user:      "testuser",
-			context:   "testcontext",
-			workspace: "testworkspace",
-			workdir:   "",
-			command:   "",
-			gpgagent:  false,
+			execPath:   "/path/to/exec",
+			host:       "testhost",
+			user:       "testuser",
+			context:    "testcontext",
+			workspace:  "testworkspace",
+			workdir:    "",
+			command:    "",
+			gpgagent:   false,
+			devPodHome: "",
 			expected: `# DevPod Start testhost
 Host testhost
   ForwardAgent yes
@@ -150,14 +179,15 @@ Host existingtesthost
 
 Host existinghost
   User existinguser`,
-			execPath:  "/path/to/exec",
-			host:      "testhost",
-			user:      "testuser",
-			context:   "testcontext",
-			workspace: "testworkspace",
-			workdir:   "",
-			command:   "",
-			gpgagent:  false,
+			execPath:   "/path/to/exec",
+			host:       "testhost",
+			user:       "testuser",
+			context:    "testcontext",
+			workspace:  "testworkspace",
+			workdir:    "",
+			command:    "",
+			gpgagent:   false,
+			devPodHome: "",
 			expected: `# DevPod Start testhost
 Host testhost
   ForwardAgent yes
@@ -191,14 +221,15 @@ Include ~/config2
 
 
 Include ~/config3`,
-			execPath:  "/path/to/exec",
-			host:      "testhost",
-			user:      "testuser",
-			context:   "testcontext",
-			workspace: "testworkspace",
-			workdir:   "",
-			command:   "",
-			gpgagent:  false,
+			execPath:   "/path/to/exec",
+			host:       "testhost",
+			user:       "testuser",
+			context:    "testcontext",
+			workspace:  "testworkspace",
+			workdir:    "",
+			command:    "",
+			gpgagent:   false,
+			devPodHome: "",
 			expected: `Include ~/config1 
 
 Include ~/config2
@@ -221,7 +252,7 @@ Host testhost
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := addHostSection(tt.config, tt.execPath, tt.host, tt.user, tt.context, tt.workspace, tt.workdir, tt.command, tt.gpgagent)
+			result, err := addHostSection(tt.config, tt.execPath, tt.host, tt.user, tt.context, tt.workspace, tt.workdir, tt.command, tt.gpgagent, tt.devPodHome)
 			if err != nil {
 				t.Errorf("Failed with err: %v", err)
 			}
@@ -247,7 +278,7 @@ Host testhost
 				t.Errorf("Result does not contain the custom ProxyCommand: %s", tt.command)
 			}
 
-			if tt.workdir != "" && !strings.Contains(result, "--workdir "+tt.workdir) {
+			if tt.workdir != "" && !strings.Contains(result, fmt.Sprintf("--workdir \"%s\"", tt.workdir)) {
 				t.Errorf("Result does not contain the workdir: %s", tt.workdir)
 			}
 


### PR DESCRIPTION
Users can specify a different location for the devpod directory other than
`~/.devpod` either by using the global flag `--devpod-home` or setting
the `DEVPOD_HOME` environment variable from DevPod Desktop or in their
shell.
This PR adds --devpod-home to the ssh config we generate after running
`devpod up ..` if it is set.
Because IDE's usually expect an ssh command, omitting the flag resulted
in non-functioning workspace.

Added another unit test for the ssh config
