### PR TITLE
fix: small typo in dotfiles-in-a-workspace.mdx

### DIFF
--- a/docs/pages/developing-in-workspaces/dotfiles-in-a-workspace.mdx
+++ b/docs/pages/developing-in-workspaces/dotfiles-in-a-workspace.mdx
@@ -31,7 +31,7 @@ a script to setup the environment.
 If none of the previous location are found, DevPod will just link every hidden file (files starting with `.`)
 in the `$HOME` directory of the container.
 
-If is possible to specify **custom install script locations** for your special setup. 
+It is possible to specify **custom install script locations** for your special setup. 
 If a custom install script is specified, DevPod will directly run that one instead.
 
 ### Via DevPod CLI


### PR DESCRIPTION
Fixing a small typo in `Personalizing a Workspace` chapter. 