### PR TITLE
Fix PR references

### DIFF
--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -179,7 +179,7 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 			err = f.DevPodProviderUse(ctx, "docker")
 			framework.ExpectNoError(err)
 
-			name := "github-com-loft-sh-devpod"
+			name := "PR3"
 			ginkgo.DeferCleanup(f.DevPodWorkspaceDelete, context.Background(), name)
 
 			// Wait for devpod workspace to come online (deadline: 30s)

--- a/examples/feature/afeature/install.sh
+++ b/examples/feature/afeature/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "hello world"
-useradd -l -m -s /bin/bash -N -u 1000 "auser"
+useradd -l -m -s /bin/bash -N -u 1001 "auser"

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -583,7 +583,9 @@ var (
 func ToID(str string) string {
 	str = strings.ToLower(filepath.ToSlash(str))
 
-	str = prReferenceRegEx.ReplaceAllStringFunc(str, git.GetBranchNameForPR)
+	if prReferenceRegEx.MatchString(str) {
+		return prReferenceRegEx.ReplaceAllStringFunc(str, git.GetBranchNameForPR)
+	}
 
 	// Check if a branch name has been specified, if so use this for the ID
 	// If not, then parse the repo name as ID

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -582,22 +582,20 @@ var (
 
 func ToID(str string) string {
 	str = strings.ToLower(filepath.ToSlash(str))
-
-	if prReferenceRegEx.MatchString(str) {
-		return prReferenceRegEx.ReplaceAllStringFunc(str, git.GetBranchNameForPR)
-	}
-
-	// Check if a branch name has been specified, if so use this for the ID
-	// If not, then parse the repo name as ID
 	splitted := strings.Split(str, "@")
-	if len(splitted) == 2 {
+
+	// 1. Check if PR was specified
+	if prReferenceRegEx.MatchString(str) {
+		str = prReferenceRegEx.ReplaceAllStringFunc(str, git.GetBranchNameForPR)
+	} else if len(splitted) == 2 {
+		// 2. Check if a branch name has been specified, if so use this for the ID
 		str = strings.TrimSuffix(splitted[1], ".git")
 		// Check if branch name matches expected regex
 		if !branchRegEx.MatchString(str) {
 			str = splitted[0]
 		}
 	} else {
-		// get last element if we find a /
+		// 3. If not, then parse the repo name as ID
 		index := strings.LastIndex(str, "/")
 		if index != -1 {
 			str = str[index+1:]

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -583,16 +583,17 @@ var (
 func ToID(str string) string {
 	str = strings.ToLower(filepath.ToSlash(str))
 	splitted := strings.Split(str, "@")
-
-	// 1. Check if PR was specified
-	if prReferenceRegEx.MatchString(str) {
-		str = prReferenceRegEx.ReplaceAllStringFunc(str, git.GetBranchNameForPR)
-	} else if len(splitted) == 2 {
-		// 2. Check if a branch name has been specified, if so use this for the ID
-		str = strings.TrimSuffix(splitted[1], ".git")
-		// Check if branch name matches expected regex
-		if !branchRegEx.MatchString(str) {
-			str = splitted[0]
+	if len(splitted) == 2 {
+		// 1. Check if PR was specified
+		if prReferenceRegEx.MatchString(str) {
+			str = prReferenceRegEx.ReplaceAllStringFunc(splitted[1], git.GetBranchNameForPR)
+		} else {
+			// 2. Check if a branch name has been specified, if so use this for the ID
+			str = strings.TrimSuffix(splitted[1], ".git")
+			// Check if branch name matches expected regex
+			if !branchRegEx.MatchString(str) {
+				str = splitted[0]
+			}
 		}
 	} else {
 		// 3. If not, then parse the repo name as ID


### PR DESCRIPTION
This PR fixes the `ToID` method to support PR references, when a PR is now used, the ID of the workspace will be `PR{id}`