### PR TITLE
Sort release versions according to semver

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -27,6 +27,7 @@
     "@tanstack/react-query-devtools": "4.36.1",
     "@tanstack/react-table": "8.10.7",
     "@tauri-apps/api": "1.5.3",
+    "compare-versions": "6.1.1",
     "dayjs": "1.11.10",
     "framer-motion": "10.16.9",
     "markdown-to-jsx": "7.3.2",

--- a/desktop/src/views/Settings/Settings.tsx
+++ b/desktop/src/views/Settings/Settings.tsx
@@ -52,6 +52,7 @@ import {
   useProxyOptions,
   useSSHKeySignatureOption,
 } from "./useSettingsOptions"
+import { compareVersions } from "compare-versions"
 
 const SETTINGS_TABS = [
   { label: "General", component: <GeneralSettings /> },
@@ -266,12 +267,14 @@ function AppearanceSettings() {
 }
 function UpdateSettings() {
   const { settings, set } = useChangeSettings()
-  const releases = useReleases()
   const platform = usePlatform()
   const arch = useArch()
   const version = useVersion()
   const [selectedVersion, setSelectedVersion] = useState<string | undefined>(undefined)
   const { isChecking, check, isUpdateAvailable, pendingUpdate } = useUpdate()
+  const releases = useReleases()
+    ?.slice()
+    .sort((a, b) => compareVersions(a.tag_name, b.tag_name))
   const downloadLink = useMemo(() => {
     const release = releases?.find((release) => release.tag_name === selectedVersion)
     if (!release) {

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -3102,6 +3102,11 @@ color2k@^2.0.2:
   resolved "https://registry.yarnpkg.com/color2k/-/color2k-2.0.3.tgz#a771244f6b6285541c82aa65ff0a0c624046e533"
   integrity sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==
 
+compare-versions@6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
+
 compute-scroll-into-view@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-3.0.3.tgz#c418900a5c56e2b04b885b54995df164535962b1"


### PR DESCRIPTION
This sorts the releases based on the tag, in descending order based on the semver.