### PR TITLE
Log and wrap error when setting up loft platform

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -254,7 +254,6 @@ func (cmd *UpCmd) Run(
 	if cmd.SetupLoftPlatformAccess {
 		err = setupLoftPlatformAccess(devPodConfig.DefaultContext, context.DefaultProvider, user, client, log)
 		if err != nil {
-			log.Error(err)
 			return err
 		}
 	}
@@ -1022,7 +1021,8 @@ func setupLoftPlatformAccess(context, provider, user string, client client2.Base
 	command := fmt.Sprintf("%v agent container setup-loft-platform-access --context %v --provider %v --port %v", agent.ContainerDevPodHelperLocation, context, provider, port)
 
 	log.Debugf("Executing command -> %v", command)
-	err = exec.Command(
+	var errb bytes.Buffer
+	cmd := exec.Command(
 		execPath,
 		"ssh",
 		"--agent-forwarding=true",
@@ -1033,9 +1033,11 @@ func setupLoftPlatformAccess(context, provider, user string, client client2.Base
 		client.Context(),
 		client.Workspace(),
 		"--command", command,
-	).Run()
+	)
+	cmd.Stderr = &errb
+	err = cmd.Run()
 	if err != nil {
-		return fmt.Errorf("failure in setting up Loft Platform access: %w", err)
+		log.Errorf("failure in setting up Loft Platform access: %s", errb.String())
 	}
 
 	return nil

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -254,6 +254,7 @@ func (cmd *UpCmd) Run(
 	if cmd.SetupLoftPlatformAccess {
 		err = setupLoftPlatformAccess(devPodConfig.DefaultContext, context.DefaultProvider, user, client, log)
 		if err != nil {
+			log.Error(err)
 			return err
 		}
 	}
@@ -1034,7 +1035,7 @@ func setupLoftPlatformAccess(context, provider, user string, client client2.Base
 		"--command", command,
 	).Run()
 	if err != nil {
-		log.Error("failure in setting up Loft Platform access")
+		return fmt.Errorf("failure in setting up Loft Platform access: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
A user reported an error setting up the loft platform

https://app.usepylon.com/issues?conversationID=4a04f1ed-4a71-47e9-8b15-46edea30fdb3

Unfortunately, we didn't log or return the error so it is difficult to debug. This PR addresses the problem by wrapping the platform error and returning it.

NOTE: Is returning the error correct? I was unsure on expected behaviour, if we can't get the executable or port number we seem to return the error. But if the loft platform access error'd then we simply logged it. If we should NOT return the error I can update the PR to simply log the wrapped error.

UPDATE: I removed returning the error as this could cause more trouble than solve until we know why the bellow happens.

UPDATE: I reproduced the error locally by simply running `devpod up https://github.com/microsoft/vscode-remote-try-go`

```
08:26:38 error failure in setting up Loft Platform access: 08:26:38 info 07:26:37 fatal unknown flag: --port
08:26:38 fatal inner tunnel: Process exited with status 1
```

These are the resulting logs. I SSH'd onto the workspace and found that the entire `setup-loft-access` command was missing from `devpod agent container`.

@janekbaraniewski can you see any way that the command would not be present? I thought we scp'd the devpod binary over the container, it's odd my local devpod had the command but on the workspace not.