### PR TITLE
fix: fix wrong parameter order

### DIFF
--- a/cmd/agent/workspace/install_dotfiles.go
+++ b/cmd/agent/workspace/install_dotfiles.go
@@ -68,7 +68,7 @@ func (cmd *InstallDotfilesCmd) Run(ctx context.Context) error {
 
 	if cmd.InstallScript != "" {
 		logger.Infof("Executing install script %s", cmd.InstallScript)
-		command := "./" + strings.TrimPrefix("./", cmd.InstallScript) + cmd.InstallScript
+		command := "./" + strings.TrimPrefix(cmd.InstallScript, "./") + cmd.InstallScript
 
 		err := ensureExecutable(command)
 		if err != nil {


### PR DESCRIPTION
There is an example:

```go
package main

import (
	"fmt"
	"strings"
)

func main() {

	cmd := struct {
		InstallScript string
	}{
		InstallScript: "./example/script.sh",
	}

	commandOld := "./" + strings.TrimPrefix("./", cmd.InstallScript)
	fmt.Println("old Constructed command:", commandOld)

	commandNew := "./" + strings.TrimPrefix(cmd.InstallScript, "./")
	fmt.Println("new Constructed command:", commandNew)
}

```


Output:

```
old Constructed command: ././
new Constructed command: ./example/script.sh
```


https://go.dev/play/p/OpHgx2LHtsp