### PR TITLE
Use correct file permission

### DIFF
--- a/pkg/provider/dir.go
+++ b/pkg/provider/dir.go
@@ -247,7 +247,7 @@ func SaveWorkspaceConfig(workspace *Workspace) error {
 	}
 
 	workspaceConfigFile := filepath.Join(workspaceDir, WorkspaceConfigFile)
-	err = os.WriteFile(workspaceConfigFile, workspaceConfigBytes, 0600)
+	err = os.WriteFile(workspaceConfigFile, workspaceConfigBytes, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/loft-sh/devpod/issues/1271

Effectively when using a repo without a .devcontainer.json, os.WriteFile creates a new file with permissions 600, instead of 644.

Looking at two examples locally
```
➜  devpod git:(feature/fix-linux-perm-issue) ✗ ls -la .devcontainer 
total 16
drwxr-xr-x  2 arthur arthur 4096 Sep  3 15:01 .
drwxr-xr-x 18 arthur arthur 4096 Sep 18 10:43 ..
-rw-r--r--  1 arthur arthur  292 Aug 23 16:34 devcontainer.json
-rw-r--r--  1 arthur arthur 1851 Sep  3 15:01 Dockerfile
➜  devpod git:(feature/fix-linux-perm-issue) ✗ ls -la ../devpod-example-devops/          
total 28
drwxr-xr-x  4 arthur arthur 4096 Sep 18 15:28 .
drwxr-xr-x 13 arthur arthur 4096 Sep 18 15:27 ..
-rw-r--r--  1 arthur arthur  443 Sep 18 15:28 .devcontainer.json
drwxr-xr-x  8 arthur arthur 4096 Sep 18 15:28 .git
drwxr-xr-x  4 arthur arthur 4096 Sep 18 15:27 .github
-rwxr-xr-x  1 arthur arthur  129 Sep 18 15:27 post-create.sh
-rw-r--r--  1 arthur arthur    8 Sep 18 15:27 README.md
```

I can see .devcontainer.json has `-rw-r--r-- ` i.e. 0644, not 600, where group or other can't read it