### PR TITLE
POD-919: Use correct file permission for generated .devcontainer.json

### DIFF
--- a/pkg/devcontainer/config/parse.go
+++ b/pkg/devcontainer/config/parse.go
@@ -59,7 +59,7 @@ func SaveDevContainerJSON(config *DevContainerConfig) error {
 		return err
 	}
 
-	err = os.WriteFile(config.Origin, out, 0600)
+	err = os.WriteFile(config.Origin, out, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
My previous PR to fix this only changed the file permission of the workspace folder, the actual .devcontainer.json still had 0600. This PR changes the file perm to 0644.

Output of reproducing the error then fixed using this build.

```
➜  ~ devpod up --id testperm https://github.com/bkneis/LLCoinJ
12:40:19 info Creating devcontainer...
12:40:19 info Clone repository
12:40:19 info URL: https://github.com/bkneis/LLCoinJ
12:40:20 done Successfully cloned repository
12:40:20 info Couldn't find a devcontainer.json
12:40:20 info Try detecting project programming language...
12:40:20 info Detected project language 'JavaScript'
12:40:20 info Inspecting image mcr.microsoft.com/devcontainers/javascript-node
12:40:20 info Image mcr.microsoft.com/devcontainers/javascript-node not found
12:40:20 info Pulling image mcr.microsoft.com/devcontainers/javascript-node
12:42:00 info 55e49ad14a56bed9223def824ec6087099e8b58ad2cb448859fbc27c00b73cb2
12:42:01 info Setup container...
12:42:01 info Chown workspace...
12:42:01 info Chown projects...
12:42:01 info Install extensions 'dbaeumer.vscode-eslint' in the background
12:42:01 info Run 'ssh testperm.devpod' to ssh into the devcontainer
12:42:01 info Starting VSCode...

➜  ~ ls -la ~/.devpod/agent/contexts/default/workspaces/testperm/content/
total 136
drwxr-xr-x 8 100999 100999  4096 Oct  2 12:40 .
drwxr-xr-x 3 arthur arthur  4096 Oct  2 12:42 ..
-rw-r--r-- 1 100999 100999    68 Oct  2 12:40 bs-config.json
drwxr-xr-x 3 100999 100999  4096 Oct  2 12:40 build
drwxr-xr-x 2 100999 100999  4096 Oct  2 12:40 contracts
-rw------- 1 100999 100999    59 Oct  2 12:40 .devcontainer.json
drwxr-xr-x 8 100999 100999  4096 Oct  2 12:40 .git
-rw-r--r-- 1 100999 100999    46 Oct  2 12:40 .gitignore
drwxr-xr-x 2 100999 100999  4096 Oct  2 12:40 migrations
-rw-r--r-- 1 100999 100999   331 Oct  2 12:40 package.json
-rw-r--r-- 1 100999 100999 81877 Oct  2 12:40 package-lock.json
-rw-r--r-- 1 100999 100999   263 Oct  2 12:40 README.md
drwxr-xr-x 6 100999 100999  4096 Oct  2 12:40 src
drwxr-xr-x 2 100999 100999  4096 Oct  2 12:40 test
-rw-r--r-- 1 100999 100999   154 Oct  2 12:40 truffle.js

➜  devpod git:(POD-919/fix-perm-issue) CGO_ENABLED=0 go build -ldflags "-s -w" -o devpod-cli
➜  devpod git:(POD-919/fix-perm-issue) ✗ ./devpod-cli up --id testpermfix https://github.com/bkneis/LLCoinJ 
12:46:56 info Creating devcontainer...
12:46:56 info Clone repository
12:46:56 info URL: https://github.com/bkneis/LLCoinJ
12:46:57 done Successfully cloned repository
12:46:57 info Couldn't find a devcontainer.json
12:46:57 info Try detecting project programming language...
12:46:57 info Detected project language 'JavaScript'
12:46:58 info Inspecting image mcr.microsoft.com/devcontainers/javascript-node
12:46:58 info 71392a40ba86eb715ab015de0182581da3b827afbcd3323915a5bff8e50a5cab
12:46:58 info Setup container...
12:46:59 info Chown workspace...
12:46:59 info Chown projects...
12:46:59 info Install extensions 'dbaeumer.vscode-eslint' in the background
12:46:59 info Run 'ssh testpermfix.devpod' to ssh into the devcontainer
12:46:59 info Starting VSCode...
➜  devpod git:(POD-919/fix-perm-issue) ✗ ./devpod-cli stop testpermfix
12:47:18 info Stopping container...
12:47:18 info Successfully stopped container...                       
➜  devpod git:(POD-919/fix-perm-issue) ✗ ls -la ~/.devpod/agent/contexts/default/workspaces/testpermfix/content/
total 136
drwxr-xr-x 8 100999 100999  4096 Oct  2 12:46 .
drwxr-xr-x 3 arthur arthur  4096 Oct  2 12:46 ..
-rw-r--r-- 1 100999 100999    68 Oct  2 12:46 bs-config.json
drwxr-xr-x 3 100999 100999  4096 Oct  2 12:46 build
drwxr-xr-x 2 100999 100999  4096 Oct  2 12:46 contracts
-rw-r--r-- 1 100999 100999    59 Oct  2 12:46 .devcontainer.json
drwxr-xr-x 8 100999 100999  4096 Oct  2 12:46 .git
-rw-r--r-- 1 100999 100999    46 Oct  2 12:46 .gitignore
drwxr-xr-x 2 100999 100999  4096 Oct  2 12:46 migrations
-rw-r--r-- 1 100999 100999   331 Oct  2 12:46 package.json
-rw-r--r-- 1 100999 100999 81877 Oct  2 12:46 package-lock.json
-rw-r--r-- 1 100999 100999   263 Oct  2 12:46 README.md
drwxr-xr-x 6 100999 100999  4096 Oct  2 12:46 src
drwxr-xr-x 2 100999 100999  4096 Oct  2 12:46 test
-rw-r--r-- 1 100999 100999   154 Oct  2 12:46 truffle.js
➜  devpod git:(POD-919/fix-perm-issue) ✗ ./devpod-cli up testpermfix
12:47:52 info Workspace testpermfix already exists
12:47:52 info Creating devcontainer...
12:47:52 info Setup container...
12:47:52 info Install extensions 'dbaeumer.vscode-eslint' in the background
12:47:52 info Run 'ssh testpermfix.devpod' to ssh into the devcontainer
12:47:52 info Starting VSCode...
➜  devpod git:(POD-919/fix-perm-issue) ✗ devpod up testperm
12:47:59 info Workspace testperm already exists
12:47:59 info Creating devcontainer...
12:47:59 info devcontainer up: parsing devcontainer.json: open /home/arthur/.devpod/agent/contexts/default/workspaces/testperm/content/.devcontainer.json: permission denied
12:47:59 error Try using the --debug flag to see a more verbose output
12:47:59 fatal run agent command: Process exited with status 1
```