### PR TITLE
Don't hardcode root when running lifecycle scripts

### DIFF
--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -70,7 +70,7 @@ func RunLifecycleHooks(ctx context.Context, setupInfo *config.Result, log log.Lo
 	return nil
 }
 
-func run(commands []types.LifecycleHook, user, dir string, remoteEnv map[string]string, name, content string, log log.Logger) error {
+func run(commands []types.LifecycleHook, remoteUser, dir string, remoteEnv map[string]string, name, content string, log log.Logger) error {
 	if len(commands) == 0 {
 		return nil
 	}
@@ -102,8 +102,8 @@ func run(commands []types.LifecycleHook, user, dir string, remoteEnv map[string]
 				log.Fatalf("Error fetching the current user: %v", err)
 			}
 			args := []string{}
-			if user != currentUser {
-				args = append(args, "su", user, "-c", command.Quote(c))
+			if remoteUser != currentUser.Username {
+				args = append(args, "su", remoteUser, "-c", command.Quote(c))
 			} else {
 				args = append(args, "sh", "-c", command.Quote(c))
 			}

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/user"
 	"regexp"
 	"slices"
 	"strings"
@@ -96,8 +97,12 @@ func run(commands []types.LifecycleHook, user, dir string, remoteEnv map[string]
 
 		for k, c := range cmd {
 			log.Infof("Run command %s: %s...", k, strings.Join(c, " "))
+			currentUser, err := user.Current()
+			if err != nil {
+				log.Fatalf("Error fetching the current user: %v", err)
+			}
 			args := []string{}
-			if user != "root" {
+			if user != currentUser {
 				args = append(args, "su", user, "-c", command.Quote(c))
 			} else {
 				args = append(args, "sh", "-c", command.Quote(c))

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -99,7 +99,7 @@ func run(commands []types.LifecycleHook, remoteUser, dir string, remoteEnv map[s
 			log.Infof("Run command %s: %s...", k, strings.Join(c, " "))
 			currentUser, err := user.Current()
 			if err != nil {
-				log.Fatalf("Error fetching the current user: %v", err)
+				return err
 			}
 			args := []string{}
 			if remoteUser != currentUser.Username {


### PR DESCRIPTION
As discussed in https://github.com/loft-sh/devpod/pull/1313#issuecomment-2416787129, this PR avoids a hardcoded assumption from the lifecycle scripts that the devpod is built under a root user.

Building the devpod under a non-root user can be important in restricted kubernetes corporate environments. While currently creating devpods under a non-root user in kubernetes requires [some further hacks](https://github.com/nrontsis/devpod-example-go/compare/63cc83c...main), this PR removes a blocking certain aspect of it, allowing for creating a devpod as per the following demo. Before this PR, the building of the devpod would stop because `"su", user, "-c", command.Quote(c)` would be called by the run lifecycle hooks logic

### Minimal example (not tested end-to-end)

```bash
devpod provider add kubernetes k8s-demo
devpod provider set-options k8s-demo \
  --option STRICT_SECURITY=true \
  --option POD_MANIFEST_TEMPLATE="$(cat k8s_template.yaml)"
devpod up git@github.com:nrontsis/devpod-example-go.git --ide=none --provider=k8s-demo --open-ide=false
```

where `k8s_template.yaml` is
```yaml
kind: Pod
apiVersion: v1
spec:
  initContainers:
  - name: set-volume-owner
    image: busybox
    command: [ "sh", "-c", "chown -R 1000:1000 /volume" ]
    volumeMounts:
    - mountPath: /volume
      name: devpod
      subPath: devpod/0
  containers:
    - name: devpod
      securityContext: 
        runAsGroup: 1000
        runAsUser: 1000
        runAsNonRoot: true
status: {}
```