### PR TITLE
fix(gpg): use symlink when setting up the gpg socket in the workspace instead of hardlink

### DIFF
--- a/pkg/gpg/gpg_forwarding.go
+++ b/pkg/gpg/gpg_forwarding.go
@@ -146,7 +146,7 @@ func (g *GPGConf) SetupRemoteSocketLink() error {
 		return err
 	}
 
-	err = exec.Command("sudo", "ln", "-f", g.SocketPath, "/tmp/S.gpg-agent").Run()
+	err = exec.Command("sudo", "ln", "-s", "-f", g.SocketPath, "/tmp/S.gpg-agent").Run()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some devcontainer features, like docker-in-docker, mount a tmpfs at
/tmp. During workspace setup with gpg agent forwarding enabled we attempt
to link the initial socket path, usually mimicking the actual path on
the users host machine, to /tmp/S.gpg-agent. Because /tmp _could be_ on
a different partition, hardlinking fails.
Changed the implementation to symlink instead. In my testing this didn't
change the behaviour, if issues arise we know where to look ;)
