### PR TITLE
Implemement .devpodignore

### DIFF
--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -373,13 +373,13 @@ func (t *tunnelServer) StreamWorkspace(message *tunnel.Empty, stream tunnel.Tunn
 	}
 
 	// Get .devpodignore files to exclude
+	excludes := []string{}
 	f, err := os.Open(filepath.Join(t.workspace.Source.LocalFolder, ".devpodignore"))
-	if err != nil {
-		return err
-	}
-	excludes, err := dockerignore.ReadAll(f)
-	if err != nil {
-		return err
+	if err == nil {
+		excludes, err = dockerignore.ReadAll(f)
+		if err != nil {
+			t.log.Warnf("Error reading .devpodignore file: %v", err)
+		}
 	}
 
 	buf := bufio.NewWriterSize(NewStreamWriter(stream, t.log), 10*1024)
@@ -405,13 +405,13 @@ func (t *tunnelServer) StreamMount(message *tunnel.StreamMountRequest, stream tu
 	}
 
 	// Get .devpodignore files to exclude
-	f, err := os.Open(filepath.Join(mount.Source, ".devpodignore"))
-	if err != nil {
-		return err
-	}
-	excludes, err := dockerignore.ReadAll(f)
-	if err != nil {
-		return err
+	excludes := []string{}
+	f, err := os.Open(filepath.Join(t.workspace.Source.LocalFolder, ".devpodignore"))
+	if err == nil {
+		excludes, err = dockerignore.ReadAll(f)
+		if err != nil {
+			t.log.Warnf("Error reading .devpodignore file: %v", err)
+		}
 	}
 
 	buf := bufio.NewWriterSize(NewStreamWriter(stream, t.log), 10*1024)

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/loft-sh/devpod/pkg/agent/tunnel"
@@ -21,6 +22,7 @@ import (
 	provider2 "github.com/loft-sh/devpod/pkg/provider"
 	"github.com/loft-sh/devpod/pkg/stdio"
 	"github.com/loft-sh/log"
+	"github.com/moby/buildkit/frontend/dockerfile/dockerignore"
 	perrors "github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -370,8 +372,18 @@ func (t *tunnelServer) StreamWorkspace(message *tunnel.Empty, stream tunnel.Tunn
 		return fmt.Errorf("workspace is nil")
 	}
 
+	// Get .devpodignore files to exclude
+	f, err := os.Open(filepath.Join(t.workspace.Source.LocalFolder, ".devpodignore"))
+	if err != nil {
+		return err
+	}
+	excludes, err := dockerignore.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
 	buf := bufio.NewWriterSize(NewStreamWriter(stream, t.log), 10*1024)
-	err := extract.WriteTar(buf, t.workspace.Source.LocalFolder, false)
+	err = extract.WriteTarExclude(buf, t.workspace.Source.LocalFolder, false, excludes)
 	if err != nil {
 		return err
 	}
@@ -392,8 +404,18 @@ func (t *tunnelServer) StreamMount(message *tunnel.StreamMountRequest, stream tu
 		return fmt.Errorf("mount %s is not allowed to download", message.Mount)
 	}
 
+	// Get .devpodignore files to exclude
+	f, err := os.Open(filepath.Join(mount.Source, ".devpodignore"))
+	if err != nil {
+		return err
+	}
+	excludes, err := dockerignore.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
 	buf := bufio.NewWriterSize(NewStreamWriter(stream, t.log), 10*1024)
-	err := extract.WriteTar(buf, mount.Source, false)
+	err = extract.WriteTarExclude(buf, mount.Source, false, excludes)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR implements the logic to support `.devpodignore` file. It has been tested using the docker and kubernetes provider with a local and git workspace source. I managed to exclude a test file from a [repo with .devpodignore](https://github.com/loft-sh/devpod-example-devops)

Fixes https://github.com/loft-sh/devpod/issues/1299