### PR TITLE
Fix prebuilds for docker compose

### DIFF
--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -412,6 +412,10 @@ func (r *runner) buildAndExtendDockerCompose(
 	var err error
 
 	buildImageName := composeService.Image
+	// If Image is empty then we are building the dev container and use the default name docker-compose uses
+	if buildImageName == "" {
+		buildImageName = fmt.Sprintf("%s-%s", project.Name, composeService.Name)
+	}
 	buildTarget := "dev_container_auto_added_stage_label"
 
 	// Determine base imageName for generated features build

--- a/pkg/devcontainer/prebuild.go
+++ b/pkg/devcontainer/prebuild.go
@@ -69,6 +69,12 @@ func (r *runner) Build(ctx context.Context, options provider.BuildOptions) (stri
 		return prebuildImage, nil
 	}
 
+	r.Log.Debug("Tagging image prebuild=%s buildInfo=%s", prebuildImage, buildInfo.ImageName)
+	err = dockerDriver.TagDevContainer(ctx, buildInfo.ImageName, prebuildImage)
+	if err != nil {
+		return "", errors.Wrap(err, "tag image")
+	}
+
 	// check if we can push image
 	err = image.CheckPushPermissions(prebuildImage)
 	if err != nil {

--- a/pkg/devcontainer/prebuild.go
+++ b/pkg/devcontainer/prebuild.go
@@ -69,7 +69,7 @@ func (r *runner) Build(ctx context.Context, options provider.BuildOptions) (stri
 		return prebuildImage, nil
 	}
 
-	if isDockerComposeConfig(parsedConfig.Config)
+	if isDockerComposeConfig(substitutedConfig.Config) {
 		r.Log.Debug("Tagging image prebuild=%s buildInfo=%s", prebuildImage, buildInfo.ImageName)
 		err = dockerDriver.TagDevContainer(ctx, buildInfo.ImageName, prebuildImage)
 		if err != nil {

--- a/pkg/devcontainer/prebuild.go
+++ b/pkg/devcontainer/prebuild.go
@@ -69,10 +69,12 @@ func (r *runner) Build(ctx context.Context, options provider.BuildOptions) (stri
 		return prebuildImage, nil
 	}
 
-	r.Log.Debug("Tagging image prebuild=%s buildInfo=%s", prebuildImage, buildInfo.ImageName)
-	err = dockerDriver.TagDevContainer(ctx, buildInfo.ImageName, prebuildImage)
-	if err != nil {
-		return "", errors.Wrap(err, "tag image")
+	if isDockerComposeConfig(parsedConfig.Config)
+		r.Log.Debug("Tagging image prebuild=%s buildInfo=%s", prebuildImage, buildInfo.ImageName)
+		err = dockerDriver.TagDevContainer(ctx, buildInfo.ImageName, prebuildImage)
+		if err != nil {
+			return "", errors.Wrap(err, "tag image")
+		}
 	}
 
 	// check if we can push image

--- a/pkg/driver/docker.go
+++ b/pkg/driver/docker.go
@@ -46,6 +46,8 @@ type DockerDriver interface {
 	// PushDevContainer pushes the given image to a registry
 	PushDevContainer(ctx context.Context, image string) error
 
+	TagDevContainer(ctx context.Context, image, tag string) error
+
 	// ComposeHelper returns the compose helper
 	ComposeHelper() (*compose.ComposeHelper, error)
 

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -108,6 +108,28 @@ func (d *dockerDriver) PushDevContainer(ctx context.Context, image string) error
 	return nil
 }
 
+func (d *dockerDriver) TagDevContainer(ctx context.Context, image, tag string) error {
+	// push image
+	writer := d.Log.Writer(logrus.InfoLevel, false)
+	defer writer.Close()
+
+	// build args
+	args := []string{
+		"tag",
+		image,
+		tag,
+	}
+
+	// run command
+	d.Log.Debugf("Running docker command: %s %s", d.Docker.DockerCommand, strings.Join(args, " "))
+	err := d.Docker.Run(ctx, args, nil, writer, writer)
+	if err != nil {
+		return errors.Wrap(err, "push image")
+	}
+
+	return nil
+}
+
 func (d *dockerDriver) DeleteDevContainer(ctx context.Context, workspaceId string) error {
 	container, err := d.FindDevContainer(ctx, workspaceId)
 	if err != nil {


### PR DESCRIPTION
Prebuilds did not work for docker compose since it's build pipeline assumed the image name, which is of course nil when using the build tag. The fix was to provide the default name docker-compose gives the the service (projectName-serviceName) and tag the built container as the devcontainer before pushing. Tested locally using docker provider

Fixes https://github.com/loft-sh/devpod/issues/1025