### PR TITLE
Add github workflow to mark issues as stale then delete after 2 months

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 30
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          days-before-issue-stale: 30
+          days-before-issue-stale: 60
           days-before-issue-close: 30
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
@@ -20,3 +20,4 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-labels: "in-progress,assigned,kind/enhancement"


### PR DESCRIPTION
I was working through some issues and think it would be nice to have some pipeline clear old issues that are not relevant. I copied this from

https://docs.github.com/en/actions/use-cases-and-examples/project-management/closing-inactive-issues

Is 3 months long enough? Any issues labelled as an enhancement or assign / in progress will be ignored so we can keep long lived feature requests for the road map. I think if a bug goes 3 months and either no one can reproduce or the reporter does not respond closing it is safe.