### PR TITLE
Implement experimental support for zed

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -330,6 +330,9 @@ func (cmd *UpCmd) Run(
 				cmd.GitUsername,
 				cmd.GitToken,
 				log)
+
+		case string(config.IDEZed):
+			return zed.Open(ctx, ideConfig.Options, config2.GetRemoteUser(result), result.SubstitutionContext.ContainerWorkspaceFolder, client.Workspace(), log)
 		}
 	}
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -30,6 +30,7 @@ import (
 	"github.com/loft-sh/devpod/pkg/ide/marimo"
 	"github.com/loft-sh/devpod/pkg/ide/openvscode"
 	"github.com/loft-sh/devpod/pkg/ide/vscode"
+	"github.com/loft-sh/devpod/pkg/ide/zed"
 	open2 "github.com/loft-sh/devpod/pkg/open"
 	"github.com/loft-sh/devpod/pkg/platform"
 	"github.com/loft-sh/devpod/pkg/port"
@@ -296,6 +297,8 @@ func (cmd *UpCmd) Run(
 			return jetbrains.NewDataSpellServer(config2.GetRemoteUser(result), ideConfig.Options, log).OpenGateway(result.SubstitutionContext.ContainerWorkspaceFolder, client.Workspace())
 		case string(config.IDEFleet):
 			return startFleet(ctx, client, log)
+		case string(config.IDEZed):
+			return zed.Open(ctx, ideConfig.Options, config2.GetRemoteUser(result), result.SubstitutionContext.ContainerWorkspaceFolder, client.Workspace(), log)
 		case string(config.IDEJupyterNotebook):
 			return startJupyterNotebookInBrowser(
 				cmd.GPGAgentForwarding,
@@ -330,9 +333,6 @@ func (cmd *UpCmd) Run(
 				cmd.GitUsername,
 				cmd.GitToken,
 				log)
-
-		case string(config.IDEZed):
-			return zed.Open(ctx, ideConfig.Options, config2.GetRemoteUser(result), result.SubstitutionContext.ContainerWorkspaceFolder, client.Workspace(), log)
 		}
 	}
 

--- a/pkg/config/ide.go
+++ b/pkg/config/ide.go
@@ -24,4 +24,5 @@ const (
 	IDEPositron        IDE = "positron"
 	IDEMarimo          IDE = "marimo"
 	IDECodium          IDE = "codium"
+	IDEZed             IDE = "zed"
 )

--- a/pkg/ide/ideparse/parse.go
+++ b/pkg/ide/ideparse/parse.go
@@ -151,13 +151,6 @@ var AllowedIDEs = []AllowedIDE{
 		Experimental: true,
 	},
 	{
-		Name:         config.IDEPositron,
-		DisplayName:  "Positron",
-		Options:      vscode.Options,
-		Icon:         "https://devpod.sh/assets/positron.svg",
-		Experimental: true,
-	},
-	{
 		Name:         config.IDEMarimo,
 		DisplayName:  "Marimo",
 		Options:      vscode.Options,
@@ -169,6 +162,13 @@ var AllowedIDEs = []AllowedIDE{
 		DisplayName:  "Codium",
 		Options:      vscode.Options,
 		Icon:         "https://devpod.sh/assets/codium.svg",
+		Experimental: true,
+	},
+	{
+		Name:         config.IDEPositron,
+		DisplayName:  "Positron",
+		Options:      vscode.Options,
+		Icon:         "https://devpod.sh/assets/positron.svg",
 		Experimental: true,
 	},
 	{

--- a/pkg/ide/ideparse/parse.go
+++ b/pkg/ide/ideparse/parse.go
@@ -171,6 +171,13 @@ var AllowedIDEs = []AllowedIDE{
 		Icon:         "https://devpod.sh/assets/codium.svg",
 		Experimental: true,
 	},
+	{
+		Name:         config.IDEZed,
+		DisplayName:  "Zed",
+		Options:      ide.Options{},
+		Icon:         "https://devpod.sh/assets/positron.svg",
+		Experimental: true,
+	},
 }
 
 func RefreshIDEOptions(devPodConfig *config.Config, workspace *provider.Workspace, ide string, options []string) (*provider.Workspace, error) {

--- a/pkg/ide/ideparse/parse.go
+++ b/pkg/ide/ideparse/parse.go
@@ -175,7 +175,7 @@ var AllowedIDEs = []AllowedIDE{
 		Name:         config.IDEZed,
 		DisplayName:  "Zed",
 		Options:      ide.Options{},
-		Icon:         "https://devpod.sh/assets/positron.svg",
+		Icon:         "https://devpod.sh/assets/zed.svg",
 		Experimental: true,
 	},
 }

--- a/pkg/ide/zed/zed.go
+++ b/pkg/ide/zed/zed.go
@@ -1,0 +1,35 @@
+package zed
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+
+	"github.com/loft-sh/devpod/pkg/command"
+	"github.com/loft-sh/log"
+
+	"github.com/loft-sh/devpod/pkg/config"
+)
+
+// Open first finds the zed binary for the local platform and then opens the zed editor with the given workspace folder
+func Open(ctx context.Context, values map[string]config.OptionValue, userName, workspaceFolder, workspaceID string, log log.Logger) error {
+	log.Info("Opening Zed editor ...")
+	// Find the zed binary for the local platform
+	zedCmd := "zed"
+	if runtime.GOOS == "darwin" && command.Exists("/Applications/Zed.app/Contents/Resources/app/bin/zed") {
+		zedCmd = "/Applications/Zed.app/Contents/Resources/app/bin/zed"
+	}
+	// Check if zed is installed and in the PATH
+	if !command.Exists(zedCmd) {
+		return fmt.Errorf("seems like you don't have zed installed on your computer locally")
+	}
+	// Open the zed editor with the given workspace ID as the SSH host and workspace folder as path
+	sshHost := fmt.Sprintf("ssh://%s.devpod/%s", workspaceID, workspaceFolder)
+	out, err := exec.CommandContext(ctx, zedCmd, sshHost).CombinedOutput()
+	if err != nil {
+		return command.WrapCommandError(out, err)
+	}
+
+	return nil
+}

--- a/pkg/ide/zed/zed.go
+++ b/pkg/ide/zed/zed.go
@@ -3,32 +3,24 @@ package zed
 import (
 	"context"
 	"fmt"
-	"os/exec"
-	"runtime"
 
-	"github.com/loft-sh/devpod/pkg/command"
 	"github.com/loft-sh/log"
+	"github.com/skratchdot/open-golang/open"
 
 	"github.com/loft-sh/devpod/pkg/config"
 )
 
 // Open first finds the zed binary for the local platform and then opens the zed editor with the given workspace folder
 func Open(ctx context.Context, values map[string]config.OptionValue, userName, workspaceFolder, workspaceID string, log log.Logger) error {
-	log.Info("Opening Zed editor ...")
-	// Find the zed binary for the local platform
-	zedCmd := "zed"
-	if runtime.GOOS == "darwin" && command.Exists("/Applications/Zed.app/Contents/Resources/app/bin/zed") {
-		zedCmd = "/Applications/Zed.app/Contents/Resources/app/bin/zed"
-	}
-	// Check if zed is installed and in the PATH
-	if !command.Exists(zedCmd) {
-		return fmt.Errorf("seems like you don't have zed installed on your computer locally")
-	}
-	// Open the zed editor with the given workspace ID as the SSH host and workspace folder as path
-	sshHost := fmt.Sprintf("ssh://%s.devpod/%s", workspaceID, workspaceFolder)
-	out, err := exec.CommandContext(ctx, zedCmd, sshHost).CombinedOutput()
+	log.Info("Opening Zed editor...")
+
+	sshHost := fmt.Sprintf("%s.devpod/%s", workspaceID, workspaceFolder)
+	openURL := fmt.Sprintf("zed://ssh/%s", sshHost)
+	err := open.Run(openURL)
 	if err != nil {
-		return command.WrapCommandError(out, err)
+		log.Debugf("Starting Zed caused error: %v", err)
+		log.Errorf("Seems like you don't have Zed installed on your computer locally")
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Fixes https://github.com/loft-sh/devpod/issues/1185

This PR adds experimental support for zed.  Please note, according to [the docs](https://zed.dev/docs/remote-development#known-limitations) remote development in zed does not support extensions. So I have not added an "Install" function to download and run the zed remote server on the container like we do vscode or jetbrains