### PR TITLE
Add experimental support for jupyter desktop

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -434,6 +434,8 @@ func (cmd *SetupContainerCmd) installIDE(setupInfo *config.Result, ide *provider
 		return fleet.NewFleetServer(config.GetRemoteUser(setupInfo), ide.Options, log).Install(setupInfo.SubstitutionContext.ContainerWorkspaceFolder)
 	case string(config2.IDEJupyterNotebook):
 		return jupyter.NewJupyterNotebookServer(setupInfo.SubstitutionContext.ContainerWorkspaceFolder, config.GetRemoteUser(setupInfo), ide.Options, log).Install()
+	case string(config2.IDEJupyterDesktop):
+		return jupyter.NewJupyterNotebookServer(setupInfo.SubstitutionContext.ContainerWorkspaceFolder, config.GetRemoteUser(setupInfo), ide.Options, log).Install()
 	}
 
 	return nil

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -355,7 +355,7 @@ func (cmd *UpCmd) Run(
 				log,
 			)
 		case string(config.IDEJupyterDesktop):
-			return startJupyterDesktopInBrowser(
+			return startJupyterDesktop(
 				cmd.GPGAgentForwarding,
 				ctx,
 				devPodConfig,
@@ -642,7 +642,7 @@ func startJupyterNotebookInBrowser(
 	)
 }
 
-func startJupyterDesktopInBrowser(
+func startJupyterDesktop(
 	forwardGpg bool,
 	ctx context.Context,
 	devPodConfig *config.Config,

--- a/pkg/config/ide.go
+++ b/pkg/config/ide.go
@@ -18,6 +18,7 @@ const (
 	IDEWebStorm        IDE = "webstorm"
 	IDEFleet           IDE = "fleet"
 	IDEJupyterNotebook IDE = "jupyternotebook"
+	IDEJupyterDesktop  IDE = "jupyterdesktop"
 	IDECursor          IDE = "cursor"
 	IDEPositron        IDE = "positron"
 )

--- a/pkg/ide/ideparse/parse.go
+++ b/pkg/ide/ideparse/parse.go
@@ -123,6 +123,14 @@ var AllowedIDEs = []AllowedIDE{
 		Experimental: true,
 	},
 	{
+		Name:         config.IDEJupyterDesktop,
+		DisplayName:  "Jupyter Desktop",
+		Options:      jupyter.Options,
+		Icon:         "https://devpod.sh/assets/jupyter.svg",
+		IconDark:     "https://devpod.sh/assets/jupyter_dark.svg",
+		Experimental: true,
+	},
+	{
 		Name:         config.IDEVSCodeInsiders,
 		DisplayName:  "VSCode Insiders",
 		Options:      vscode.Options,

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -12,6 +12,7 @@ import (
 	"github.com/skratchdot/open-golang/open"
 )
 
+// Open opens the given url in the default application, retrying every second until the context is done
 func Open(ctx context.Context, url string, log log.Logger) error {
 	for {
 		select {
@@ -26,10 +27,7 @@ func Open(ctx context.Context, url string, log log.Logger) error {
 	}
 }
 
-func jlabOpen(url string) error {
-	return exec.Command("jlab", url).Run()
-}
-
+// JLabDesktop opens the given url in the JLab desktop application, retrying every second until the context is done
 func JLabDesktop(ctx context.Context, url string, log log.Logger) error {
 	for {
 		select {
@@ -42,6 +40,10 @@ func JLabDesktop(ctx context.Context, url string, log log.Logger) error {
 			}
 		}
 	}
+}
+
+func jlabOpen(url string) error {
+	return exec.Command("jlab", url).Run()
 }
 
 func tryOpen(ctx context.Context, url string, fn func(string) error, log log.Logger) error {


### PR DESCRIPTION
Tested using ./devpod-cli --ide jupyterdesktop --id j5 up https://github.com/microsoft/vscode-remote-try-python

Since we already have the jupyter server logic we only needed to find and enable the client :)