### PR TITLE
Wrap devpodignore with nil check on workspace

### DIFF
--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -419,16 +419,18 @@ func (t *tunnelServer) StreamMount(message *tunnel.StreamMountRequest, stream tu
 
 	// Get .devpodignore files to exclude
 	excludes := []string{}
-	f, err := os.Open(filepath.Join(t.workspace.Source.LocalFolder, ".devpodignore"))
-	if err == nil {
-		excludes, err = dockerignore.ReadAll(f)
-		if err != nil {
-			t.log.Warnf("Error reading .devpodignore file: %v", err)
+	if t.workspace != nil {
+		f, err := os.Open(filepath.Join(t.workspace.Source.LocalFolder, ".devpodignore"))
+		if err == nil {
+			excludes, err = dockerignore.ReadAll(f)
+			if err != nil {
+				t.log.Warnf("Error reading .devpodignore file: %v", err)
+			}
 		}
 	}
 
 	buf := bufio.NewWriterSize(NewStreamWriter(stream, t.log), 10*1024)
-	err = extract.WriteTarExclude(buf, mount.Source, false, excludes)
+	err := extract.WriteTarExclude(buf, mount.Source, false, excludes)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
```
14:57:51 info panic: runtime error: invalid memory address or nil pointer dereference
14:57:51 info [signal SIGSEGV: segmentation violation code=0x1 addr=0xc8 pc=0x2209227]
14:57:51 info 
14:57:51 info goroutine 219 [running]:
14:57:51 info github.com/loft-sh/devpod/pkg/agent/tunnelserver.(*tunnelServer).StreamMount(0xc00045e150, 0xc000911b40, {0x3274b60, 0xc000b07860})
14:57:51 info 	/home/runner/work/devpod/devpod/pkg/agent/tunnelserver/tunnelserver.go:422 +0x127
14:57:51 info github.com/loft-sh/devpod/pkg/agent/tunnel._Tunnel_StreamMount_Handler({0x2cab740, 0xc00045e150}, {0x3271810, 0xc000536690})
14:57:51 info 	/home/runner/work/devpod/devpod/pkg/agent/tunnel/tunnel_grpc.pb.go:551 +0x107
14:57:51 info google.golang.org/grpc.(*Server).processStreamingRPC(0xc0000db800, {0x3269c88, 0xc000b78780}, {0x3278720, 0xc000167080}, 0xc000ad6fc0, 0xc000a034a0, 0x4c09740, 0x0)
14:57:51 info 	/home/runner/work/devpod/devpod/vendor/google.golang.org/grpc/server.go:1673 +0x1208
14:57:51 info google.golang.org/grpc.(*Server).handleStream(0xc0000db800, {0x3278720, 0xc000167080}, 0xc000ad6fc0)
14:57:51 info 	/home/runner/work/devpod/devpod/vendor/google.golang.org/grpc/server.go:1794 +0xe3a
14:57:51 info google.golang.org/grpc.(*Server).serveStreams.func2.1()
14:57:51 info 	/home/runner/work/devpod/devpod/vendor/google.golang.org/grpc/server.go:1029 +0x8b
14:57:51 info created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 242
14:57:51 info 	/home/runner/work/devpod/devpod/vendor/google.golang.org/grpc/server.go:1040 +0x125
14:57:51 debug Connection to SSH Server closed
14:57:51 debug Done creating devcontainer
14:57:51 fatal Process exited with status 2
run agent command
github.com/loft-sh/devpod/pkg/devcontainer/sshtunnel.ExecuteCommand.func2
	/home/runner/work/devpod/devpod/pkg/devcontainer/sshtunnel/sshtunnel.go:129
runtime.goexit
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/runtime/asm_amd64.s:1695
  [FAILED] in [It] - /home/runner/work/devpod/devpod/e2e/tests/build/build.go:203 @ 11/01/24 14:57:51.819
```


Unit test was seen failing, it's due to workspace potentially being nil. This PR fixes by wrapping the use of the workspace with a nil check. I did this over an early return as I assume StreamMount can in fact have a nil workspace? The other functions have this check but StreamMount does not