### PR TITLE
Adds ability for user to define additional tags for images

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -52,6 +52,14 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("cannot push to %s, please make sure you have push permissions to repository %s", cmd.Repository, cmd.Repository)
 				}
+
+				if cmd.Tag != nil {
+					err = image.ValidateTags(cmd.Tag)
+
+					if err != nil {
+						return fmt.Errorf("cannot build image, invalid tag defined %s", cmd.Tag)
+					}
+				}
 			}
 
 			// create a temporary workspace
@@ -112,6 +120,7 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 	buildCmd.Flags().BoolVar(&cmd.SkipDelete, "skip-delete", false, "If true will not delete the workspace after building it")
 	buildCmd.Flags().StringVar(&cmd.Machine, "machine", "", "The machine to use for this workspace. The machine needs to exist beforehand or the command will fail. If the workspace already exists, this option has no effect")
 	buildCmd.Flags().StringVar(&cmd.Repository, "repository", "", "The repository to push to")
+	buildCmd.Flags().StringSliceVar(&cmd.Tag, "tag", []string{}, "Image Tag(s) in the form of a comma separated list --tag latest,arm64 or multiple flags --tag latest --tag arm64")
 	buildCmd.Flags().StringSliceVar(&cmd.Platform, "platform", []string{}, "Set target platform for build")
 	buildCmd.Flags().BoolVar(&cmd.SkipPush, "skip-push", false, "If true will not push the image to the repository, useful for testing")
 	buildCmd.Flags().Var(&cmd.GitCloneStrategy, "git-clone-strategy", "The git clone strategy DevPod uses to checkout git based workspaces. Can be full (default), blobless, treeless or shallow")

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -52,13 +52,14 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("cannot push to %s, please make sure you have push permissions to repository %s", cmd.Repository, cmd.Repository)
 				}
+			}
 
-				if cmd.Tag != nil {
-					err = image.ValidateTags(cmd.Tag)
+			// validate tags
+			if cmd.Tag != nil {
+				err = image.ValidateTags(cmd.Tag)
 
-					if err != nil {
-						return fmt.Errorf("cannot build image, invalid tag defined %s", cmd.Tag)
-					}
+				if err != nil {
+					return fmt.Errorf("cannot build image, %v", err)
 				}
 			}
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -55,11 +55,9 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 			}
 
 			// validate tags
-			if cmd.Tag != nil {
-				err = image.ValidateTags(cmd.Tag)
-
-				if err != nil {
-					return fmt.Errorf("cannot build image, %v", err)
+			if len(cmd.Tag) > 0 {
+				if err := image.ValidateTags(cmd.Tag); err != nil {
+					return fmt.Errorf("cannot build image, %w", err)
 				}
 			}
 

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -104,6 +104,7 @@ func (r *runner) build(
 			ImageName:     overrideBuildImageName,
 			PrebuildHash:  imageTag,
 			RegistryCache: options.RegistryCache,
+			Tags:          options.Tag,
 		}, nil
 	}
 
@@ -135,6 +136,7 @@ func (r *runner) extendImage(
 			ImageMetadata: extendedBuildInfo.MetadataConfig,
 			ImageName:     imageBase,
 			RegistryCache: options.RegistryCache,
+			Tags:          options.Tag,
 		}, nil
 	}
 
@@ -322,6 +324,7 @@ func (r *runner) buildImage(
 					ImageName:     prebuildImage,
 					PrebuildHash:  prebuildHash,
 					RegistryCache: options.RegistryCache,
+					Tags:          options.Tag,
 				}, nil
 			} else if err != nil {
 				r.Log.Debugf("Error trying to find prebuild image %s: %v", prebuildImage, err)
@@ -385,6 +388,7 @@ func dockerlessFallback(
 			User: buildInfo.User,
 		},
 		RegistryCache: options.RegistryCache,
+		Tags:          options.Tag,
 	}, nil
 }
 

--- a/pkg/devcontainer/config/build.go
+++ b/pkg/devcontainer/config/build.go
@@ -22,6 +22,7 @@ type BuildInfo struct {
 	ImageName     string
 	PrebuildHash  string
 	RegistryCache string
+	Tags          []string
 
 	Dockerless *BuildInfoDockerless
 }

--- a/pkg/driver/docker/build.go
+++ b/pkg/driver/docker/build.go
@@ -46,6 +46,7 @@ func (d *dockerDriver) BuildDevContainer(
 				ImageName:     imageName,
 				PrebuildHash:  prebuildHash,
 				RegistryCache: options.RegistryCache,
+				Tags:          options.Tag,
 			}, nil
 		} else if err != nil {
 			d.Log.Debugf("Error trying to find local image %s: %v", imageName, err)
@@ -114,6 +115,7 @@ func (d *dockerDriver) BuildDevContainer(
 		ImageName:     imageName,
 		PrebuildHash:  prebuildHash,
 		RegistryCache: options.RegistryCache,
+		Tags:          options.Tag,
 	}, nil
 }
 

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -112,7 +112,7 @@ func (d *dockerDriver) PushDevContainer(ctx context.Context, image string) error
 }
 
 func (d *dockerDriver) TagDevContainer(ctx context.Context, image, tag string) error {
-	// push image
+	// Tag image
 	writer := d.Log.Writer(logrus.InfoLevel, false)
 	defer writer.Close()
 
@@ -127,7 +127,7 @@ func (d *dockerDriver) TagDevContainer(ctx context.Context, image, tag string) e
 	d.Log.Debugf("Running docker command: %s %s", d.Docker.DockerCommand, strings.Join(args, " "))
 	err := d.Docker.Run(ctx, args, nil, writer, writer)
 	if err != nil {
-		return errors.Wrap(err, "push image")
+		return errors.Wrap(err, "tag image")
 	}
 
 	return nil

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -3,13 +3,14 @@ package image
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"regexp"
+
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/pkg/errors"
-	"net/http"
-	"regexp"
 )
 
 var (

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -67,21 +67,14 @@ func GetImageConfig(ctx context.Context, image string) (*v1.ConfigFile, v1.Image
 func ValidateTags(tags []string) error {
 	for _, tag := range tags {
 		if !IsValidDockerTag(tag) {
-			return fmt.Errorf(`%q is not a valid docker tag
-
- - a tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes;
- - a tag name may not start with a period or a dash and may contain a maximum of 128 characters.`, tag)
+			return fmt.Errorf(`%q is not a valid docker tag`, tag)
 		}
 	}
 	return nil
 }
 
 func IsValidDockerTag(tag string) bool {
-	if shouldNotBeSlugged(tag, dockerTagRegexp, DockerTagMaxSize) {
-		return true
-	}
-
-	return false
+	return shouldNotBeSlugged(tag, dockerTagRegexp, DockerTagMaxSize)
 }
 
 func shouldNotBeSlugged(data string, regexp *regexp.Regexp, maxSize int) bool {

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -222,6 +222,7 @@ type CLIOptions struct {
 	Repository string   `json:"repository,omitempty"`
 	SkipPush   bool     `json:"skipPush,omitempty"`
 	Platform   []string `json:"platform,omitempty"`
+	Tag        []string `json:"tag,omitempty"`
 
 	ForceBuild            bool   `json:"forceBuild,omitempty"`
 	ForceDockerless       bool   `json:"forceDockerless,omitempty"`


### PR DESCRIPTION
Adds new build cli flag `tag` that will tag the image with the user defined tag and then push

Example CLI command
`./devpod-cli build . --devcontainer-path ./devcontainer.json --force-build --debug --tag test,arm64`