### PR TITLE
fix(ssh-workspace-id): fixes parsing for git ssh urls

### DIFF
--- a/pkg/workspace/id.go
+++ b/pkg/workspace/id.go
@@ -19,7 +19,9 @@ var (
 func ToID(str string) string {
 	str = strings.ToLower(filepath.ToSlash(str))
 	splitted := strings.Split(str, "@")
-	if len(splitted) == 2 {
+	isSshRef := len(splitted) > 1 && strings.LastIndex(str, ":") > -1;
+
+	if len(splitted) == 2 && !isSshRef {
 		// 1. Check if PR was specified
 		if prReferenceRegEx.MatchString(str) {
 			str = prReferenceRegEx.ReplaceAllStringFunc(splitted[1], git.GetIDForPR)


### PR DESCRIPTION
**Issue**:
When creating a workspace from a git repository using an SSH URL, the ID parser does not properly detect the repo name. For example, the command `devpod up git@github.com:loft-sh/devpod.git` results in a workspace ID of "github-com-loft-sh-devpod". When created via HTTPS, the workspace ID is "devpod".

**Expectation**:
The workspace ID generation should be consistent across git URLs.

**Fix**:
The fix is to detect the presence of ":" when "@" is present - if so, we can use the standard parsing mechanism that uses the last index of "/" and strips ".git".

**Notes**:
This is my first contribution to this project. Please let me know if this is the expected functionality, if my implementation may have unwanted side effects, or if I need to update any tests/documentation. Thanks!