### PR TITLE
Add positional arguments to CLI usage string

### DIFF
--- a/cmd/machine/create.go
+++ b/cmd/machine/create.go
@@ -18,13 +18,13 @@ type CreateCmd struct {
 	ProviderOptions []string
 }
 
-// NewCreateCmd creates a new destroy command
+// NewCreateCmd creates a new create command
 func NewCreateCmd(flags *flags.GlobalFlags) *cobra.Command {
 	cmd := &CreateCmd{
 		GlobalFlags: flags,
 	}
 	createCmd := &cobra.Command{
-		Use:   "create",
+		Use:   "create [name]",
 		Short: "Creates a new machine",
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cmd.Run(context.Background(), args)

--- a/cmd/machine/delete.go
+++ b/cmd/machine/delete.go
@@ -26,7 +26,7 @@ func NewDeleteCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	deleteCmd := &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [name]",
 		Short: "Deletes an existing machine",
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cmd.Run(context.Background(), args)

--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -36,7 +36,7 @@ func NewSSHCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	sshCmd := &cobra.Command{
-		Use:   "ssh",
+		Use:   "ssh [name]",
 		Short: "SSH into the machine",
 		RunE: func(c *cobra.Command, args []string) error {
 			return cmd.Run(context.Background(), args)

--- a/cmd/machine/start.go
+++ b/cmd/machine/start.go
@@ -22,7 +22,7 @@ func NewStartCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	startCmd := &cobra.Command{
-		Use:   "start",
+		Use:   "start [name]",
 		Short: "Starts an existing machine",
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cmd.Run(context.Background(), args)

--- a/cmd/machine/status.go
+++ b/cmd/machine/status.go
@@ -26,7 +26,7 @@ func NewStatusCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	statusCmd := &cobra.Command{
-		Use:   "status",
+		Use:   "status [name]",
 		Short: "Retrieves the status of an existing machine",
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cmd.Run(context.Background(), args)

--- a/cmd/machine/stop.go
+++ b/cmd/machine/stop.go
@@ -22,7 +22,7 @@ func NewStopCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	stopCmd := &cobra.Command{
-		Use:   "stop",
+		Use:   "stop [name]",
 		Short: "Stops an existing machine",
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cmd.Run(context.Background(), args)

--- a/cmd/provider/add.go
+++ b/cmd/provider/add.go
@@ -33,7 +33,7 @@ func NewAddCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	addCmd := &cobra.Command{
-		Use:   "add",
+		Use:   "add [URL or path]",
 		Short: "Adds a new provider to DevPod",
 		PreRunE: func(cobraCommand *cobra.Command, args []string) error {
 			if cmd.FromExisting != "" {

--- a/cmd/provider/delete.go
+++ b/cmd/provider/delete.go
@@ -29,7 +29,7 @@ func NewDeleteCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	deleteCmd := &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [name]",
 		Short: "Delete a provider",
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cmd.Run(context.Background(), args)

--- a/cmd/provider/update.go
+++ b/cmd/provider/update.go
@@ -26,7 +26,7 @@ func NewUpdateCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	updateCmd := &cobra.Command{
-		Use:   "update",
+		Use:   "update [name] [URL or path]",
 		Short: "Updates a provider in DevPod",
 		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/cmd/provider/use.go
+++ b/cmd/provider/use.go
@@ -35,7 +35,7 @@ func NewUseCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: *flags,
 	}
 	useCmd := &cobra.Command{
-		Use:   "use",
+		Use:   "use [name]",
 		Short: "Configure an existing provider and set as default",
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) != 1 {


### PR DESCRIPTION
Positional arguments like the machine name or provider name are undocumented in the CLI. This commit adds them to the "Use" string so that they show up with the --help flag.