### PR TITLE
Only report erorrs not EOF since this is expected when the SSH session ends

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -349,7 +349,7 @@ func (cmd *SSHCmd) reverseForwardPorts(
 				timeout,
 				log,
 			)
-			if err != nil {
+			if !errors.Is(io.EOF, err) {
 				errChan <- fmt.Errorf("error forwarding %s: %w", portMapping, err)
 			}
 		}(portMapping)
@@ -394,7 +394,7 @@ func (cmd *SSHCmd) forwardPorts(
 				timeout,
 				log,
 			)
-			if err != nil {
+			if !errors.Is(io.EOF, err) {
 				errChan <- fmt.Errorf("error forwarding %s: %w", portMapping, err)
 			}
 		}(portMapping)


### PR DESCRIPTION
Currently when you end a SSH session that has port forwarding or reverse forwarding an error is printed superfluously. The underlying EOF error is expected since the sessions was closed so it should not be reported. This was confusing an OSS user and when using reverse forward it's printed locally and makes it seem the command failed. This PR fixes it by checking if it is EOF

e.g.

```
07:15:03 error error forwarding /run/user/1000/gnupg/S.gpg-agent.extra: EOF
```