### PR TITLE
Feature/fix builds docker syntax

### DIFF
--- a/examples/build/Dockerfile
+++ b/examples/build/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM mcr.microsoft.com/devcontainers/go:1.22-bullseye
 
 ARG TARGETOS

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -181,6 +181,8 @@ func (r *runner) buildAndExtendImage(
 		return nil, errors.Wrap(err, "get image build info")
 	}
 
+	r.Log.Info("============= Building image dockerfile syntax ", imageBuildInfo.Dockerfile.Syntax)
+
 	// get extend image build info
 	extendedBuildInfo, err := feature.GetExtendedBuildInfo(substitutionContext, imageBuildInfo.Metadata, imageBuildInfo.User, imageBase, parsedConfig, r.Log, options.ForceBuild)
 	if err != nil {

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -124,7 +124,7 @@ func (r *runner) extendImage(
 	}
 
 	// get extend image build info
-	extendedBuildInfo, err := feature.GetExtendedBuildInfo(substitutionContext, imageBuildInfo.Metadata, imageBuildInfo.User, imageBase, parsedConfig, r.Log, options.ForceBuild)
+	extendedBuildInfo, err := feature.GetExtendedBuildInfo(substitutionContext, imageBuildInfo, imageBase, parsedConfig, r.Log, options.ForceBuild)
 	if err != nil {
 		return nil, errors.Wrap(err, "get extended build info")
 	}
@@ -181,10 +181,8 @@ func (r *runner) buildAndExtendImage(
 		return nil, errors.Wrap(err, "get image build info")
 	}
 
-	r.Log.Info("============= Building image dockerfile syntax ", imageBuildInfo.Dockerfile.Syntax)
-
 	// get extend image build info
-	extendedBuildInfo, err := feature.GetExtendedBuildInfo(substitutionContext, imageBuildInfo.Metadata, imageBuildInfo.User, imageBase, parsedConfig, r.Log, options.ForceBuild)
+	extendedBuildInfo, err := feature.GetExtendedBuildInfo(substitutionContext, imageBuildInfo, imageBase, parsedConfig, r.Log, options.ForceBuild)
 	if err != nil {
 		return nil, errors.Wrap(err, "get extended build info")
 	}

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -457,7 +457,7 @@ func (r *runner) buildAndExtendDockerCompose(
 		}
 	}
 
-	extendImageBuildInfo, err := feature.GetExtendedBuildInfo(substitutionContext, imageBuildInfo.Metadata, imageBuildInfo.User, buildTarget, parsedConfig, r.Log, false)
+	extendImageBuildInfo, err := feature.GetExtendedBuildInfo(substitutionContext, imageBuildInfo, buildTarget, parsedConfig, r.Log, false)
 	if err != nil {
 		return "", "", nil, "", err
 	}

--- a/pkg/devcontainer/feature/extend.go
+++ b/pkg/devcontainer/feature/extend.go
@@ -51,13 +51,13 @@ type BuildInfo struct {
 	BuildArgs               map[string]string
 }
 
-func GetExtendedBuildInfo(substitutionContext *config.SubstitutionContext, baseImageMetadata *config.ImageMetadataConfig, user, target string, devContainerConfig *config.SubstitutedConfig, log log.Logger, forceBuild bool) (*ExtendedBuildInfo, error) {
+func GetExtendedBuildInfo(ctx *config.SubstitutionContext, imageBuildInfo *config.ImageBuildInfo, target string, devContainerConfig *config.SubstitutedConfig, log log.Logger, forceBuild bool) (*ExtendedBuildInfo, error) {
 	features, err := fetchFeatures(devContainerConfig.Config, log, forceBuild)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch features")
 	}
 
-	mergedImageMetadataConfig, err := metadata.GetDevContainerMetadata(substitutionContext, baseImageMetadata, devContainerConfig, features)
+	mergedImageMetadataConfig, err := metadata.GetDevContainerMetadata(ctx, imageBuildInfo.Metadata, devContainerConfig, features)
 	if err != nil {
 		return nil, errors.Wrap(err, "get dev container metadata")
 	}
@@ -76,7 +76,7 @@ func GetExtendedBuildInfo(substitutionContext *config.SubstitutionContext, baseI
 	}
 
 	contextPath := config.GetContextPath(devContainerConfig.Config)
-	buildInfo, err := getFeatureBuildOptions(contextPath, baseImageMetadata, user, target, features)
+	buildInfo, err := getFeatureBuildOptions(contextPath, imageBuildInfo, target, features)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +89,8 @@ func GetExtendedBuildInfo(substitutionContext *config.SubstitutionContext, baseI
 	}, nil
 }
 
-func getFeatureBuildOptions(contextPath string, baseImageMetadata *config.ImageMetadataConfig, user, target string, features []*config.FeatureSet) (*BuildInfo, error) {
-	containerUser, remoteUser := findContainerUsers(baseImageMetadata, "", user)
+func getFeatureBuildOptions(contextPath string, imageBuildInfo *config.ImageBuildInfo, target string, features []*config.FeatureSet) (*BuildInfo, error) {
+	containerUser, remoteUser := findContainerUsers(imageBuildInfo.Metadata, "", imageBuildInfo.User)
 
 	// copy features
 	featureFolder := filepath.Join(contextPath, config.DevPodContextFeatureFolder)
@@ -108,9 +108,14 @@ _REMOTE_USER=`+remoteUser+"\n"), 0600)
 
 	// prepare dockerfile
 	dockerfileContent := strings.ReplaceAll(FEATURE_BASE_DOCKERFILE, "#{featureLayer}", getFeatureLayers(containerUser, remoteUser, features))
-	dockerfilePrefix := `
-# syntax=docker.io/docker/dockerfile:1.4
-ARG _DEV_CONTAINERS_BASE_IMAGE=placeholder`
+	// get build syntax from Dockerfile or use default
+	syntax := "docker.io/docker/dockerfile:1.4"
+	if imageBuildInfo.Dockerfile.Syntax != "" {
+		syntax = imageBuildInfo.Dockerfile.Syntax
+	}
+	dockerfilePrefix := fmt.Sprintf(`
+# syntax=%s
+ARG _DEV_CONTAINERS_BASE_IMAGE=placeholder`, syntax)
 
 	return &BuildInfo{
 		FeaturesFolder:          featureFolder,
@@ -119,7 +124,7 @@ ARG _DEV_CONTAINERS_BASE_IMAGE=placeholder`
 		OverrideTarget:          "dev_containers_target_stage",
 		BuildArgs: map[string]string{
 			"_DEV_CONTAINERS_BASE_IMAGE": target,
-			"_DEV_CONTAINERS_IMAGE_USER": user,
+			"_DEV_CONTAINERS_IMAGE_USER": imageBuildInfo.User,
 		},
 	}, nil
 }

--- a/pkg/devcontainer/feature/extend.go
+++ b/pkg/devcontainer/feature/extend.go
@@ -110,7 +110,7 @@ _REMOTE_USER=`+remoteUser+"\n"), 0600)
 	dockerfileContent := strings.ReplaceAll(FEATURE_BASE_DOCKERFILE, "#{featureLayer}", getFeatureLayers(containerUser, remoteUser, features))
 	// get build syntax from Dockerfile or use default
 	syntax := "docker.io/docker/dockerfile:1.4"
-	if imageBuildInfo.Dockerfile.Syntax != "" {
+	if imageBuildInfo.Dockerfile != nil && imageBuildInfo.Dockerfile.Syntax != "" {
 		syntax = imageBuildInfo.Dockerfile.Syntax
 	}
 	dockerfilePrefix := fmt.Sprintf(`

--- a/pkg/dockerfile/parse.go
+++ b/pkg/dockerfile/parse.go
@@ -259,7 +259,7 @@ type Dockerfile struct {
 
 	Directives []*parser.Directive
 	Preamble   *Preamble
-	Syntax     string
+	Syntax     string // https://docs.docker.com/build/concepts/dockerfile/#dockerfile-syntax
 
 	Stages         []*Stage
 	StagesByTarget map[string]*Stage
@@ -335,7 +335,7 @@ func Parse(dockerfileContent string) (*Dockerfile, error) {
 	}
 	d.Directives = directives
 
-	// parse syntax
+	// parse build syntax
 	for _, directive := range directives {
 		if directive.Name == "syntax" {
 			d.Syntax = directive.Value

--- a/pkg/dockerfile/parse.go
+++ b/pkg/dockerfile/parse.go
@@ -259,6 +259,7 @@ type Dockerfile struct {
 
 	Directives []*parser.Directive
 	Preamble   *Preamble
+	Syntax     string
 
 	Stages         []*Stage
 	StagesByTarget map[string]*Stage
@@ -333,6 +334,14 @@ func Parse(dockerfileContent string) (*Dockerfile, error) {
 		return nil, err
 	}
 	d.Directives = directives
+
+	// parse syntax
+	for _, directive := range directives {
+		if directive.Name == "syntax" {
+			d.Syntax = directive.Value
+			break
+		}
+	}
 
 	// parse instructions
 	isPreamble := true


### PR DESCRIPTION
This PR fixes https://github.com/loft-sh/devpod/issues/1481

In summary devpod always assumes a build syntax of docker/dockerfile:1.4. The reference CLI parses out the build syntax and uses it in the feature layers - https://github.com/devcontainers/cli/blob/main/src/spec-node/containerFeatures.ts#L200

This PR does the same falling back to 1.4 if no build syntax is specified.

I tested this using examples/build and adding the problematic build commands such as `RUN --checksum` and watching it fail then work with the PR