### PR TITLE
Base 64 encode and decode signing key

### DIFF
--- a/cmd/agent/container/credentials_server.go
+++ b/cmd/agent/container/credentials_server.go
@@ -3,6 +3,7 @@ package container
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -147,7 +148,11 @@ func (cmd *CredentialsServerCmd) Run(ctx context.Context, port int, runnerPort i
 
 	// configure git ssh signature helper
 	if cmd.GitUserSigningKey != "" {
-		err = gitsshsigning.ConfigureHelper(cmd.User, cmd.GitUserSigningKey, log)
+		decodedKey, err := base64.StdEncoding.DecodeString(cmd.GitUserSigningKey)
+		if err != nil {
+			return fmt.Errorf("decode git ssh signature key: %w", err)
+		}
+		err = gitsshsigning.ConfigureHelper(cmd.User, string(decodedKey), log)
 		if err != nil {
 			return fmt.Errorf("configure git ssh signature helper: %w", err)
 		}

--- a/pkg/tunnel/services.go
+++ b/pkg/tunnel/services.go
@@ -3,6 +3,7 @@ package tunnel
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -118,7 +119,8 @@ func RunInContainer(
 		if configureGitSSHSignatureHelper {
 			format, userSigningKey, err := gitsshsigning.ExtractGitConfiguration()
 			if err == nil && format == gitsshsigning.GPGFormatSSH && userSigningKey != "" {
-				command += fmt.Sprintf(" --git-user-signing-key %s", userSigningKey)
+				encodedKey := base64.StdEncoding.EncodeToString([]byte(userSigningKey))
+				command += fmt.Sprintf(" --git-user-signing-key %s", encodedKey)
 			}
 		}
 		if configureDockerCredentials {


### PR DESCRIPTION
Fixes https://github.com/loft-sh/devpod/issues/1438

Not sure how to test this one. I ran up using the problematic workspace and could SSH and use my git credentials. But since my signing key doesn't cause an issue I can't replicate. But I can confirm the base64 decode / encode works