### PR TITLE
Detect arch when getting image for prebuild

### DIFF
--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -307,7 +307,7 @@ func (r *runner) buildImage(
 		r.Log.Debugf("Try to find prebuild image %s in repositories %s", prebuildHash, strings.Join(options.PrebuildRepositories, ","))
 		for _, prebuildRepo := range options.PrebuildRepositories {
 			prebuildImage := prebuildRepo + ":" + prebuildHash
-			img, err := image.GetImage(ctx, prebuildImage)
+			img, err := image.GetImageForArch(ctx, prebuildImage, targetArch)
 			if err == nil && img != nil {
 				// prebuild image found
 				r.Log.Infof("Found existing prebuilt image %s", prebuildImage)

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -37,6 +37,30 @@ func GetImage(ctx context.Context, image string) (v1.Image, error) {
 	return img, err
 }
 
+func GetImageForArch(ctx context.Context, image, arch string) (v1.Image, error) {
+	ref, err := name.ParseReference(image)
+	if err != nil {
+		return nil, err
+	}
+
+	keychain, err := getKeychain(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create authentication keychain: %w", err)
+	}
+
+	remoteOptions := []remote.Option{
+		remote.WithAuthFromKeychain(keychain),
+		remote.WithPlatform(v1.Platform{Architecture: arch, OS: "linux"}),
+	}
+
+	img, err := remote.Image(ref, remoteOptions...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "retrieve image %s", image)
+	}
+
+	return img, err
+}
+
 func CheckPushPermissions(image string) error {
 	ref, err := name.ParseReference(image)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/loft-sh/devpod/issues/1490

I can't test this though since I am not on ARM :(

I believe there should be a follow up task in improving how we get the image from the registry for kubernetes provider. Currently there are other instances of image.GetImage but have no way of knowing the arch yet. Most other instances also only need to know if the image exists which can be done more cost effectively then getting the entire image. Additionally performing this check requires the local user to be authenticated to the registry.