### PR TITLE
Provide a default value for TMPDIR in the case none is given

### DIFF
--- a/hack/rebuild.sh
+++ b/hack/rebuild.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if [[ -z "${TMPDIR}" ]]; then
+    TMPDIR="/tmp"
+fi
+
 if [[ -z "${BUILD_PLATFORMS}" ]]; then
     BUILD_PLATFORMS="linux windows darwin"
 fi


### PR DESCRIPTION
Simple fix - if TMPDIR isn't set, default it to /tmp

resolves **https://github.com/loft-sh/devpod/issues/1510**