### PR TITLE
cli: add an environment variable to disable telemetry globally

### DIFF
--- a/docs/pages/other-topics/telemetry.mdx
+++ b/docs/pages/other-topics/telemetry.mdx
@@ -47,7 +47,7 @@ Below you can find an example of the payload that DevPod CLI would send to our t
 
 ### Telemetry opt-out process
 
-To disable the telemetry execute the following command:
+To disable the telemetry, set the environment variable `DEVPOD_DISABLE_TELEMETRY=true`. It can also be opted out for individual context by executing the following command:
 
 ```bash
 devpod context set-options -o TELEMETRY=false

--- a/docs/pages/other-topics/telemetry.mdx
+++ b/docs/pages/other-topics/telemetry.mdx
@@ -32,9 +32,9 @@ Below you can find an example of the payload that DevPod CLI would send to our t
       "provider":"kubernetes",              # the default provider
       "source_type":"git:",                 # the workspace source type (git, image, local, container, unknown)
       "ide":"vscode",                       # the IDE used to open a workspace
-      "desktop":"true",                     # whether this cli command has been executed by DevPod Desktop or is a direct CLI invokation
+      "desktop":"true",                     # whether this cli command has been executed by DevPod Desktop or is a direct CLI invocation
       "version":"v0.5.29",                  # the CLI version
-      "error":"provider 'docker' does not exist" # an error that occured during command execution
+      "error":"provider 'docker' does not exist" # an error that occurred during command execution
     }
   },
   "user":{

--- a/pkg/telemetry/collect.go
+++ b/pkg/telemetry/collect.go
@@ -49,7 +49,8 @@ type CLICollector interface {
 // StartCLI starts collecting events and sending them to the backend from the CLI
 func StartCLI(devPodConfig *config.Config, cmd *cobra.Command) {
 	telemetryOpt := devPodConfig.ContextOption(config.ContextOptionTelemetry)
-	if telemetryOpt == "false" || version.GetVersion() == version.DevVersion {
+	if telemetryOpt == "false" || version.GetVersion() == version.DevVersion ||
+		os.Getenv("DEVPOD_DISABLE_TELEMETRY") == "true" {
 		return
 	}
 


### PR DESCRIPTION
With the current model described at <https://devpod.sh/docs/other-topics/telemetry#telemetry-opt-out-process>, a CLI user wanting to opt out of telemetry completely needs to remember to set the TELEMTRY option for every new context.

This PR adds an additional environment variable as a method to disable telemetry regardless of the current context. This is a common approach among open-sourced CLI programs.