### PR TITLE
Replace the usage of go-homedir with os.UserHomeDir()

### DIFF
--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -21,7 +21,6 @@ import (
 	"github.com/denisbrodbeck/machineid"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/mgutz/ansi"
-	"github.com/mitchellh/go-homedir"
 	"github.com/skratchdot/open-golang/open"
 
 	storagev1 "github.com/loft-sh/api/v4/pkg/apis/storage/v1"
@@ -1693,7 +1692,7 @@ func getMachineUID(log log.Logger) string {
 	}
 	// get $HOME to distinguish two users on the same machine
 	// will be hashed later together with the ID
-	home, err := homedir.Dir()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		home = "error"
 		if log != nil {

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/loft-sh/ssh v0.0.4
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.18.0
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
@@ -160,6 +159,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect

--- a/pkg/agent/workspace.go
+++ b/pkg/agent/workspace.go
@@ -16,7 +16,6 @@ import (
 	"github.com/loft-sh/devpod/pkg/gitcredentials"
 	provider2 "github.com/loft-sh/devpod/pkg/provider"
 	"github.com/loft-sh/log"
-	"github.com/mitchellh/go-homedir"
 	"github.com/moby/patternmatcher/ignorefile"
 )
 
@@ -50,7 +49,7 @@ func findDir(agentFolder string, validate func(path string) bool) string {
 	}
 
 	// check home folder first
-	homeDir, _ := homedir.Dir()
+	homeDir, _ := os.UserHomeDir()
 	if homeDir != "" {
 		homeDir = filepath.Join(homeDir, ".devpod", "agent")
 		if validate(homeDir) {

--- a/pkg/command/user.go
+++ b/pkg/command/user.go
@@ -1,14 +1,13 @@
 package command
 
 import (
+	"os"
 	"os/user"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 func GetHome(userName string) (string, error) {
 	if userName == "" {
-		return homedir.Dir()
+		return os.UserHomeDir()
 	}
 
 	u, err := user.Lookup(userName)

--- a/pkg/config/dir.go
+++ b/pkg/config/dir.go
@@ -3,8 +3,6 @@ package config
 import (
 	"os"
 	"path/filepath"
-
-	homedir "github.com/mitchellh/go-homedir"
 )
 
 // Override devpod home
@@ -19,7 +17,7 @@ func GetConfigDir() (string, error) {
 		return homeDir, nil
 	}
 
-	homeDir, err := homedir.Dir()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -5,12 +5,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/denisbrodbeck/machineid"
 	"github.com/google/uuid"
 	"github.com/loft-sh/log"
-	"github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -81,7 +81,7 @@ func GetMachineUID(log log.Logger) string {
 	}
 	// get $HOME to distinguish two users on the same machine
 	// will be hashed later together with the ID
-	home, err := homedir.Dir()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		home = "error"
 		if log != nil {

--- a/pkg/ide/fleet/fleet.go
+++ b/pkg/ide/fleet/fleet.go
@@ -18,7 +18,6 @@ import (
 	"github.com/loft-sh/devpod/pkg/single"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/scanner"
-	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 )
 
@@ -215,7 +214,7 @@ func prepareFleetServerLocation(userName string) (string, error) {
 	if userName != "" {
 		homeFolder, err = command.GetHome(userName)
 	} else {
-		homeFolder, err = homedir.Dir()
+		homeFolder, err = os.UserHomeDir()
 	}
 	if err != nil {
 		return "", err

--- a/pkg/ide/jetbrains/generic.go
+++ b/pkg/ide/jetbrains/generic.go
@@ -18,7 +18,6 @@ import (
 	devpodhttp "github.com/loft-sh/devpod/pkg/http"
 	"github.com/loft-sh/devpod/pkg/ide"
 	"github.com/loft-sh/log"
-	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/skratchdot/open-golang/open"
 )
@@ -134,7 +133,7 @@ func getBaseFolder(userName string) (string, error) {
 	if userName != "" {
 		homeFolder, err = command.GetHome(userName)
 	} else {
-		homeFolder, err = homedir.Dir()
+		homeFolder, err = os.UserHomeDir()
 	}
 	if err != nil {
 		return "", err

--- a/pkg/ide/openvscode/openvscode.go
+++ b/pkg/ide/openvscode/openvscode.go
@@ -17,7 +17,6 @@ import (
 	"github.com/loft-sh/devpod/pkg/ide/vscode"
 	"github.com/loft-sh/devpod/pkg/single"
 	"github.com/loft-sh/log"
-	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -280,7 +279,7 @@ func prepareOpenVSCodeServerLocation(userName string) (string, error) {
 	if userName != "" {
 		homeFolder, err = command.GetHome(userName)
 	} else {
-		homeFolder, err = homedir.Dir()
+		homeFolder, err = os.UserHomeDir()
 	}
 	if err != nil {
 		return "", err

--- a/pkg/ide/vscode/vscode.go
+++ b/pkg/ide/vscode/vscode.go
@@ -14,7 +14,6 @@ import (
 	copy2 "github.com/loft-sh/devpod/pkg/copy"
 	"github.com/loft-sh/devpod/pkg/ide"
 	"github.com/loft-sh/log"
-	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -421,7 +420,7 @@ func prepareServerLocation(userName string, create bool, flavor Flavor) (string,
 	if userName != "" {
 		homeFolder, err = command.GetHome(userName)
 	} else {
-		homeFolder, err = homedir.Dir()
+		homeFolder, err = os.UserHomeDir()
 	}
 	if err != nil {
 		return "", err

--- a/pkg/platform/client/client.go
+++ b/pkg/platform/client/client.go
@@ -26,7 +26,6 @@ import (
 	"github.com/loft-sh/devpod/pkg/platform/project"
 	"github.com/loft-sh/devpod/pkg/version"
 	"github.com/loft-sh/log"
-	"github.com/mitchellh/go-homedir"
 	perrors "github.com/pkg/errors"
 	"github.com/skratchdot/open-golang/open"
 	"k8s.io/client-go/rest"
@@ -48,7 +47,7 @@ const (
 )
 
 func init() {
-	hd, _ := homedir.Dir()
+	hd, _ := os.UserHomeDir()
 	if folder, ok := os.LookupEnv("LOFT_CACHE_FOLDER"); ok {
 		CacheFolder = filepath.Join(hd, folder)
 	} else {

--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/scanner"
-	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 )
 
@@ -186,7 +185,7 @@ func writeSSHConfig(path, content string, log log.Logger) error {
 }
 
 func ResolveSSHConfigPath(sshConfigPath string) (string, error) {
-	homeDir, err := homedir.Dir()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", errors.Wrap(err, "get home dir")
 	}

--- a/pkg/ssh/keys.go
+++ b/pkg/ssh/keys.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/loft-sh/devpod/pkg/provider"
-	"github.com/mitchellh/go-homedir"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
@@ -80,7 +79,7 @@ func GetPrivateKeyRaw(context, workspaceID string) ([]byte, error) {
 }
 
 func GetDevPodKeysDir() string {
-	dir, err := homedir.Dir()
+	dir, err := os.UserHomeDir()
 	if err == nil {
 		tempDir := filepath.Join(dir, ".devpod", "keys")
 		err = os.MkdirAll(tempDir, 0755)

--- a/pkg/ssh/ssh_add.go
+++ b/pkg/ssh/ssh_add.go
@@ -11,7 +11,6 @@ import (
 	"github.com/loft-sh/devpod/pkg/command"
 	devsshagent "github.com/loft-sh/devpod/pkg/ssh/agent"
 	"github.com/loft-sh/log"
-	"github.com/mitchellh/go-homedir"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -41,7 +40,7 @@ func AddPrivateKeysToAgent(ctx context.Context, log log.Logger) error {
 }
 
 func FindPrivateKeys() ([]string, error) {
-	homeDir, err := homedir.Dir()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/telemetry/helpers.go
+++ b/pkg/telemetry/helpers.go
@@ -4,9 +4,9 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"fmt"
+	"os"
 
 	"github.com/denisbrodbeck/machineid"
-	"github.com/mitchellh/go-homedir"
 )
 
 // GetMachineID retrieves machine ID and encodes it together with users $HOME path and
@@ -19,7 +19,7 @@ func GetMachineID() string {
 
 	// get $HOME to distinguish two users on the same machine
 	// will be hashed later together with the ID
-	home, err := homedir.Dir()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		home = "error"
 	}


### PR DESCRIPTION
`go-homedir` project has been archived for a long time. `os.UserHomeDir()` returns the same value set so we can use it as a drop-in replacement. Sadly, some vendored modules still depend on `go-homedir`. The offended modules are `github.com/awslabs/amazon-ecr-credential-helper` and `github.com/Azure/go-autorest`, which are both pulled by the direct dependency `github.com/google/go-containerregistry/pkg/authn/k8schain`.

Ref: https://github.com/mitchellh/go-homedir/issues/34