### PR TITLE
fix(desktop): do not block specifying options if command is used from desktop. The options will be filled in later

### DIFF
--- a/cmd/provider/set_options.go
+++ b/cmd/provider/set_options.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/loft-sh/devpod/cmd/flags"
 	"github.com/loft-sh/devpod/pkg/config"
@@ -63,7 +64,7 @@ func (cmd *SetOptionsCmd) Run(ctx context.Context, args []string, log log.Logger
 	}
 	log.Debugf("providerName=%+v", providerName)
 
-	if len(cmd.Options) == 0 {
+	if os.Getenv("DEVPOD_UI") == "" && len(cmd.Options) == 0 {
 		return fmt.Errorf("please specify option")
 	}
 	log.Debugf("Options=%+v", cmd.Options)


### PR DESCRIPTION
fixes #1507 