### PR TITLE
Check if URL contains basic auth in URL

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -58,8 +58,17 @@ func NormalizeRepository(str string) (string, string, string, string, string) {
 	// resolve branch
 	branch := ""
 	if match := branchRegEx.FindStringSubmatch(str); match != nil {
-		str = match[1]
-		branch = match[2]
+		// Check if basic auth is used, if so concat the user info and URL
+		if strings.Contains(match[1], ":") {
+			str = match[1] + "@" + match[2]
+			if innerMatch := branchRegEx.FindStringSubmatch(str); innerMatch != nil {
+				str = innerMatch[1]
+				branch = innerMatch[2]
+			}
+		} else {
+			str = match[1]
+			branch = match[2]
+		}
 	}
 
 	// resolve commit hash

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -23,8 +23,8 @@ const (
 // WARN: Make sure this matches the regex in /desktop/src/views/Workspaces/CreateWorkspace/CreateWorkspaceInput.tsx!
 var (
 	// Updated regex pattern to support SSH-style Git URLs
-	repoBaseRegEx    = `((?:(?:https?|git|ssh|file):\/\/)?\/?(?:[^@\/\n]+@)?(?:[^:\/\n]+)(?:[:\/][^\/\n]+)+(?:\.git)?)`
-	branchRegEx      = regexp.MustCompile(`^` + repoBaseRegEx + `@([a-zA-Z0-9\./\-\_]+)$`)
+	repoBaseRegEx    = `((?:(?:https?|git|ssh|file):\/\/)?(?:[^:@\/\n]+(?::[^@\/\n]+)?@)?(?:[^:\/\n]+|(?:\/[^\/\n]+)+)(?:[:\/][^\/\n]+)+(?:\.git))`
+	branchRegEx      = regexp.MustCompile(`^` + repoBaseRegEx + `(?:@([a-zA-Z0-9\./\-\_]+))?$`)
 	commitRegEx      = regexp.MustCompile(`^` + repoBaseRegEx + regexp.QuoteMeta(CommitDelimiter) + `([a-zA-Z0-9]+)$`)
 	prReferenceRegEx = regexp.MustCompile(`^` + repoBaseRegEx + `@(` + PullRequestReference + `)$`)
 	subPathRegEx     = regexp.MustCompile(`^` + repoBaseRegEx + regexp.QuoteMeta(SubPathDelimiter) + `([a-zA-Z0-9\./\-\_]+)$`)
@@ -58,17 +58,8 @@ func NormalizeRepository(str string) (string, string, string, string, string) {
 	// resolve branch
 	branch := ""
 	if match := branchRegEx.FindStringSubmatch(str); match != nil {
-		// Check if basic auth is used, if so concat the user info and URL
-		if strings.Contains(match[1], ":") {
-			str = match[1] + "@" + match[2]
-			if innerMatch := branchRegEx.FindStringSubmatch(str); innerMatch != nil {
-				str = innerMatch[1]
-				branch = innerMatch[2]
-			}
-		} else {
-			str = match[1]
-			branch = match[2]
-		}
+		str = match[1]
+		branch = match[2]
 	}
 
 	// resolve commit hash


### PR DESCRIPTION
Fixes https://github.com/loft-sh/devpod/issues/1515 by checking if the URL contains basic auth (detected from the presence of : in the first part of the URL). The URL is then parsed again in case both basic auth AND a branch were specified.

If there is a fancier way of doing this with regex let me know :)

My test below shows the original problem with the URL parsed, then building my changes and testing the same URL and again with a branch (note the lines with URL: and Branch:)

```
➜  devpod git:(main) devpod up https://gitlab-ci-token:my-token-here@gitlab.com/my-group/my-repo.git
10:16:13 info Creating devcontainer...
10:16:14 info Clone repository
10:16:14 info URL: https://gitlab-ci-token:my-token-here
10:16:14 info Branch: gitlab.com/my-group/my-repo.git
...

➜  devpod git:(main) CGO_ENABLED=0 go build -ldflags "-s -w" -o devpod-cli

➜  devpod git:(main) ✗ ./devpod-cli up https://gitlab-ci-token:my-token-here@gitlab.com/my-group/my-repo.git 
10:23:42 info Creating devcontainer...
10:23:43 info Delete old workspace 'gitlab-com-my-group-my-repo'
10:23:43 info Clone repository
10:23:43 info URL: https://gitlab-ci-token:my-token-here@gitlab.com/my-group/my-repo.git
...

➜  devpod git:(main) ✗ ./devpod-cli up https://gitlab-ci-token:my-token-here@gitlab.com/my-group/my-repo.git@branch
10:25:30 info Creating devcontainer...
10:25:30 info Delete old workspace 'my-repo-git-branch'
10:25:30 info Clone repository
10:25:30 info URL: https://gitlab-ci-token:my-token-here@gitlab.com/my-group/my-repo.git
10:25:30 info Branch: branch
...
```