### PR TITLE
Support COMPOSE_PROJECT_NAME

### DIFF
--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -190,6 +191,10 @@ func (h *ComposeHelper) FindProjectFiles(ctx context.Context, projectName string
 }
 
 func (h *ComposeHelper) GetProjectName(runnerID string) string {
+	// Check for project name override - https://docs.docker.com/compose/how-tos/project-name/
+	if projectNameOverride := os.Getenv("COMPOSE_PROJECT_NAME"); projectNameOverride != "" {
+		return projectNameOverride
+	}
 	return h.toProjectName(runnerID)
 }
 


### PR DESCRIPTION
Fixes https://github.com/loft-sh/devpod/issues/1513

Currently we always set the docker compose project name, using the `--project-name (-p)` flag in `pkg/devcontainer/compose.go`, with an auto generated name. This is the highest priority way of setting the project name according to the docs and therefore can never to overridden.

This PR introduces the ability for a user to set the project name via an env var so that the project name be known in advance. Since this is supported by docker-compose I thought we should support as well. See the issue for an example of not knowing the project name.

To test this PR set the env var `COMPOSE_PROJECT_NAME=test` and run devpod up using a docker compose example to see the naming taking effect.