### PR TITLE
chore/open vscode logs

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -449,7 +449,7 @@ func (cmd *SetupContainerCmd) installIDE(setupInfo *config.Result, ide *provider
 }
 
 func (cmd *SetupContainerCmd) setupVSCode(setupInfo *config.Result, ideOptions map[string]config2.OptionValue, flavor vscode.Flavor, log log.Logger) error {
-	log.Debugf("Setup %s...", flavor)
+	log.Debugf("Setup %s...", flavor.DisplayName())
 	vsCodeConfiguration := config.GetVSCodeConfiguration(setupInfo.MergedConfig)
 	settings := ""
 	if len(vsCodeConfiguration.Settings) > 0 {

--- a/pkg/ide/vscode/open.go
+++ b/pkg/ide/vscode/open.go
@@ -2,6 +2,7 @@ package vscode
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -14,14 +15,13 @@ import (
 
 func Open(ctx context.Context, workspace, folder string, newWindow bool, flavor Flavor, log log.Logger) error {
 	log.Infof("Starting %s...", flavor)
-	err := openViaCLI(ctx, workspace, folder, newWindow, flavor, log)
-	if err != nil {
-		log.Debugf("Error opening %s via cli: %v", flavor, err)
-	} else {
+	cliErr := openViaCLI(ctx, workspace, folder, newWindow, flavor, log)
+	if cliErr == nil {
 		return nil
 	}
 
-	return openViaBrowser(workspace, folder, newWindow, flavor, log)
+	browserErr := openViaBrowser(workspace, folder, newWindow, flavor, log)
+	return errors.Join(cliErr, browserErr)
 }
 
 func openViaBrowser(workspace, folder string, newWindow bool, flavor Flavor, log log.Logger) error {

--- a/pkg/ide/vscode/open.go
+++ b/pkg/ide/vscode/open.go
@@ -14,13 +14,17 @@ import (
 )
 
 func Open(ctx context.Context, workspace, folder string, newWindow bool, flavor Flavor, log log.Logger) error {
-	log.Infof("Starting %s...", flavor)
+	log.Infof("Starting %s...", flavor.DisplayName())
 	cliErr := openViaCLI(ctx, workspace, folder, newWindow, flavor, log)
 	if cliErr == nil {
 		return nil
 	}
 
 	browserErr := openViaBrowser(workspace, folder, newWindow, flavor, log)
+	if browserErr == nil {
+		return nil
+	}
+
 	return errors.Join(cliErr, browserErr)
 }
 

--- a/pkg/ide/vscode/vscode.go
+++ b/pkg/ide/vscode/vscode.go
@@ -33,6 +33,23 @@ const (
 	FlavorCodium   Flavor = "codium"
 )
 
+func (f Flavor) DisplayName() string {
+	switch f {
+	case FlavorStable:
+		return "VSCode"
+	case FlavorInsiders:
+		return "VSCode Insiders"
+	case FlavorCursor:
+		return "Cursor"
+	case FlavorPositron:
+		return "positron"
+	case FlavorCodium:
+		return "VSCodium"
+	default:
+		return "VSCode"
+	}
+}
+
 var Options = ide.Options{
 	OpenNewWindow: {
 		Name:        OpenNewWindow,


### PR DESCRIPTION
- **chore(cli): only report errors when opening VSCode if at least one method from CLI and custom scheme actually fails**
- **chore(cli): add displayName to VSCode flavor for clearer log output**
