### PR TITLE
feat: add log level to environment variables sent to provider

### DIFF
--- a/pkg/provider/env.go
+++ b/pkg/provider/env.go
@@ -8,13 +8,15 @@ import (
 	"strings"
 
 	"github.com/loft-sh/devpod/pkg/config"
+	log2 "github.com/loft-sh/log"
 )
 
 const (
 	// general
-	DEVPOD      = "DEVPOD"
-	DEVPOD_OS   = "DEVPOD_OS"
-	DEVPOD_ARCH = "DEVPOD_ARCH"
+	DEVPOD           = "DEVPOD"
+	DEVPOD_OS        = "DEVPOD_OS"
+	DEVPOD_ARCH      = "DEVPOD_ARCH"
+	DEVPOD_LOG_LEVEL = "DEVPOD_LOG_LEVEL"
 
 	// workspace
 	WORKSPACE_ID       = "WORKSPACE_ID"
@@ -183,6 +185,7 @@ func GetBaseEnvironment(context, provider string) map[string]string {
 	retVars[PROVIDER_CONTEXT] = context
 	providerFolder, _ := GetProviderDir(context, provider)
 	retVars[PROVIDER_FOLDER] = filepath.ToSlash(providerFolder)
+	retVars[DEVPOD_LOG_LEVEL] = log2.Default.GetLevel().String()
 	return retVars
 }
 


### PR DESCRIPTION
## Description
This adds a `DEVPOD_LOG_LEVEL` environment variable to the environment variables sent to the provider.

### Design decisions

- I chose this approach because it allows for further granular log levels in future.
- I used the `DEVPOD_` prefix because it seemed to be in that section of options.

### Discussion

Any data received from the provider will be output at the `info` level because it's only doing a simple "send everything to `info`" rather than receiving any metadata to say the log level. My opinion would be to get this in today to allow debug logs to be output and then overhaul the log metadata as a future task.

## Issue
Fixes https://github.com/loft-sh/devpod/issues/1537

## How to test

In order to receive the log level in the provider, you should do something like [this](https://github.com/mrsimonemms/devpod-provider-hetzner/blob/6465c90933e72a6259c0483dd3917933577ba4e4/cmd/root.go#L32,L45).

Now run the binary:

```bash
devpod up --debug <target>
```

This will then tell the provider to set to the log level to `debug`.