### PR TITLE
chore(dev): improve devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,6 @@
 {
-  "name": "Go",
-  "build": {
-    "dockerfile": "Dockerfile"
-  },
-  "remoteUser": "vscode",
-  "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "latest"
-    },
-    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
-      "version": "latest"
-    },
-    "ghcr.io/dhoeric/features/k9s:1": {
-      "version": "latest"
-    }
-  }
+  "name": "DevPod Development",
+  "image": "ghcr.io/loft-sh/devpod:dev",
+  "remoteUser": "devpod",
+  "postCreateCommand": "bash ./.devcontainer/post_create.sh"
 }

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,0 +1,28 @@
+
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  echo "[POST_CREATE] $*"
+}
+
+REBUILD_SCRIPT="./hack/rebuild.sh"
+
+if [[ ! -f "$REBUILD_SCRIPT" ]]; then
+  log "Error: Rebuild script not found at $REBUILD_SCRIPT" >&2
+  exit 1
+fi
+
+
+log "Building initial version of devpod binary"
+chmod +x "$REBUILD_SCRIPT"
+BUILD_PLATFORMS="linux" "$REBUILD_SCRIPT"
+
+# Add our user to docker group 
+sudo usermod -aG docker $USER
+
+log "Installing docker provider with default options"
+devpod provider add docker
+
+log "Done"

--- a/.github/devcontainer/Dockerfile
+++ b/.github/devcontainer/Dockerfile
@@ -3,6 +3,10 @@ FROM mcr.microsoft.com/devcontainers/go:1.22-bullseye
 ARG TARGETOS
 ARG TARGETARCH
 
+# We want to setup our own user later, this removes the built-in VSCode user 
+# that comes with the base image
+RUN sudo userdel -r vscode -f || true && rm -rf /home/vscode
+
 # Install Node.js
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
@@ -17,3 +21,11 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends protobuf-compiler \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Install kind 
+RUN curl -L -o kind "https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-${TARGETARCH}" && install -c -m 0755 kind /usr/local/bin && rm kind
+
+# Install alacritty terminfo
+RUN wget https://raw.githubusercontent.com/alacritty/alacritty/master/extra/alacritty.info \
+    && sudo tic -xe alacritty,alacritty-direct alacritty.info \
+    && rm alacritty.info

--- a/.github/devcontainer/devcontainer.json
+++ b/.github/devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "DevPod Development Image",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true,
+      "installOhMyZsh": true,
+      "installOhMyZshConfig": true,
+      "upgradePackages": true,
+      "username": "devpod"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "version": "latest"
+    },
+    "ghcr.io/dhoeric/features/k9s:1": {
+      "version": "latest"
+    }
+  }
+}

--- a/.github/workflows/build-devcontainer-image.yaml
+++ b/.github/workflows/build-devcontainer-image.yaml
@@ -1,0 +1,41 @@
+name: Build Dev Container
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    paths:
+      - ".github/devcontainer/**"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: "write"
+      contents: "read"
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v1
+
+      - name: Prepare DevPod
+        run: |
+          curl -L -o devpod "https://github.com/loft-sh/devpod/releases/latest/download/devpod-linux-amd64" \
+            && sudo install -c -m 0755 devpod /usr/local/bin \
+            && rm -f devpod
+          devpod provider add docker
+
+      - name: "Build and push image"
+        run: |
+          devpod build . --devcontainer-path .github/devcontainer/devcontainer.json --platform linux/amd64,linux/arm64 --skip-push
+          # Change tag to `latest`
+          ID=$(docker images --format "{{.ID}} {{.CreatedAt}} {{.Tag}}" | sort -rk 2 | grep "devpod" | awk 'NR==1{print $1}')
+          echo "found image: $ID"
+          if [ -z "${ID}" ]; then
+            echo "Image ID empty, exiting"
+            exit 0 
+          fi 
+          docker image ls
+          docker tag $ID ghcr.io/loft-sh/devpod:dev
+          docker push ghcr.io/loft-sh/devpod:dev


### PR DESCRIPTION
Splits the devcontainer into two distinct parts: one for building the
image and one for consuming and adding lifecycle commands.
The image-building devcontainer.json uses devcontainer features and
populates the `ghcr.io/loft-sh/devpod:dev` image.
The top-level devcontainer.json consumes the image and adds lifecycle
commands and potentially other properties that don't force the image to
change to it.

Also added a couple of smaller niceties
