### PR TITLE
fix(git): add support for `credential.useHttpPath`

### DIFF
--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -214,6 +214,21 @@ func (t *tunnelServer) GitCredentials(ctx context.Context, message *tunnel.Messa
 		credentials.Username = t.gitCredentialsOverride.username
 		credentials.Password = t.gitCredentialsOverride.token
 	} else {
+		if t.workspace.Source.GitRepository != "" {
+			path, err := gitcredentials.GetHTTPPath(ctx, gitcredentials.GetHttpPathParameters{
+				Host:        credentials.Host,
+				Protocol:    credentials.Protocol,
+				CurrentPath: credentials.Path,
+				Repository:  t.workspace.Source.GitRepository,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("get http path: %w", err)
+			}
+			// Set the credentials `path` field to the path component of the git repository URL.
+			// This allows downstream credential helpers to figure out which passwords needs to be fetched
+			credentials.Path = path
+		}
+
 		response, err := gitcredentials.GetCredentials(credentials)
 		if err != nil {
 			return nil, perrors.Wrap(err, "get git response")


### PR DESCRIPTION
In some scenarios the host machines git config sets `credential.useHttpPath=true` but the git config in either the agent or actual workspace doesn't.
Until now this would break git credential forwarding because we wouldn't provide the `path` component to the machines git credential helper.