### PR TITLE
Bump go to 1.23

### DIFF
--- a/.github/devcontainer/Dockerfile
+++ b/.github/devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.22-bullseye
+FROM mcr.microsoft.com/devcontainers/go:1.23-bullseye
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
tsnet requires go 23 so bumping so we can develop in our dog fooding set up