### PR TITLE
Remove deb upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -448,33 +448,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload deb Asset
-        if: matrix.settings.host == 'ubuntu-22.04' && matrix.settings.cli_only == false
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const fs = require("fs")
-
-            const releaseId = "${{ needs.create-release.outputs.release_id }}"
-            const assetName = "DevPod_${{needs.create-release.outputs.package_version}}_${{ matrix.settings.arch }}.deb"
-            const assetPath = `desktop/src-tauri/target/${{ matrix.settings.target }}/release/bundle/deb/${assetName}`
-
-            console.log("Attempting to upload release asset: ", assetName)
-
-            await github.rest.repos.uploadReleaseAsset({
-              headers: {
-                "content-type": "application/zip",
-                "content-length": fs.statSync(assetPath).size
-              },
-              name: assetName,
-              data: fs.readFileSync(assetPath),
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: releaseId
-            })
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   publish-updates:
     needs: [build-app, create-release]
     if: startsWith(github.ref, 'refs/tags/v') == true


### PR DESCRIPTION
The release successfully built the .deb package, but a previous step already uploaded as a build asset - https://github.com/loft-sh/devpod/actions/runs/12784785685/job/35638481557#step:22:85

Yet you can see the asset here - https://github.com/loft-sh/devpod/releases

This PR remove the manual deb upload