### PR TITLE
fix(Zed): remove the double leading slashes on project

### DIFF
--- a/pkg/ide/zed/zed.go
+++ b/pkg/ide/zed/zed.go
@@ -16,7 +16,11 @@ import (
 func Open(ctx context.Context, values map[string]config.OptionValue, userName, workspaceFolder, workspaceID string, log log.Logger) error {
 	log.Info("Opening Zed editor...")
 
-	sshHost := fmt.Sprintf("%s.devpod/%s", workspaceID, workspaceFolder)
+	if len(workspaceFolder) == 0 || workspaceFolder[0] != '/' {
+		workspaceFolder = fmt.Sprintf("/%s", workspaceFolder)
+	}
+
+	sshHost := fmt.Sprintf("%s.devpod%s", workspaceID, workspaceFolder)
 	openURL := fmt.Sprintf("zed://ssh/%s", sshHost)
 	err := open.Run(openURL)
 	if err != nil {

--- a/pkg/ide/zed/zed_linux.go
+++ b/pkg/ide/zed/zed_linux.go
@@ -16,7 +16,11 @@ import (
 func Open(ctx context.Context, values map[string]config.OptionValue, userName, workspaceFolder, workspaceID string, log log.Logger) error {
 	log.Info("Opening Zed editor...")
 
-	sshHost := fmt.Sprintf("%s.devpod/%s", workspaceID, workspaceFolder)
+	if len(workspaceFolder) == 0 || workspaceFolder[0] != '/' {
+		workspaceFolder = fmt.Sprintf("/%s", workspaceFolder)
+	}
+
+	sshHost := fmt.Sprintf("%s.devpod%s", workspaceID, workspaceFolder)
 	openURL := fmt.Sprintf("zed://ssh/%s", sshHost)
 	out, err := exec.Command("xdg-open", openURL).CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
This fixes an issue where project opened in Zed are opened as `//workspace/project/` instead of `/workspace/project/`. generally, the double slashes doesn't seem to prevent Zed to function. However, a few alert may arise in the logs depending of the used LSP and extensions.