### PR TITLE
fix/create pro workspace trailing slash

### DIFF
--- a/cmd/pro/create_workspace.go
+++ b/cmd/pro/create_workspace.go
@@ -68,7 +68,7 @@ func (cmd *CreateWorkspaceCmd) Run(ctx context.Context) error {
 	// ignore --debug because we tunnel json through stdio
 	cmd.Log.SetLevel(logrus.InfoLevel)
 
-	if err := clientimplementation.RunCommandWithBinaries(
+	err = clientimplementation.RunCommandWithBinaries(
 		ctx,
 		"createWorkspace",
 		provider.Exec.Proxy.Create.Workspace,
@@ -81,9 +81,7 @@ func (cmd *CreateWorkspaceCmd) Run(ctx context.Context) error {
 		nil,
 		&buf,
 		cmd.Log.ErrorStreamOnly().Writer(logrus.ErrorLevel, true),
-		cmd.Log); err != nil {
-		return fmt.Errorf("create workspace with provider \"%s\": %w", provider.Name, err)
-	}
+		cmd.Log)
 	if err != nil {
 		return fmt.Errorf("create workspace: %w", err)
 	}

--- a/pkg/workspace/id.go
+++ b/pkg/workspace/id.go
@@ -32,6 +32,8 @@ func ToID(str string) string {
 			}
 		}
 	} else {
+		// Ensure we don't have a single trailing slash
+		str = strings.TrimSuffix(str, "/")
 		// 3. If not, then parse the repo name as ID
 		index := strings.LastIndex(str, "/")
 		if index != -1 {

--- a/pkg/workspace/id_test.go
+++ b/pkg/workspace/id_test.go
@@ -1,0 +1,78 @@
+package workspace
+
+import (
+	"testing"
+)
+
+// TestToID takes in a string which represents a workspace source and returns an appropriate
+// _human readable_ ID for it.
+// Note that these tests document the status quo and not the ideal state.
+// I've created follow up tickets to adjust the ToID function and update the tests but because
+// this is a potentially breaking change we'll have to wait for the next major version.
+func TestToID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "Simple URL, no @, parse repo name",
+			input: "github.com/loft-sh/devpod",
+			want:  "devpod",
+		},
+		{
+			name:  "URL with .git suffix",
+			input: "github.com/loft-sh/devpod.git",
+			want:  "devpod",
+		},
+		{
+			name:  "URL with .git suffix and https prefix",
+			input: "https://github.com/loft-sh/devpod.git",
+			want:  "devpod",
+		},
+		{
+			name:  "URL with trailing slash",
+			input: "github.com/loft-sh/devpod/",
+			want:  "devpod",
+		},
+		{
+			name:  "Bare string with no slash",
+			input: "myrepo",
+			want:  "myrepo",
+		},
+		{
+			name:  "Local directory",
+			input: "/home/loft/devpod",
+			want:  "devpod",
+		},
+		{
+			name:  "Branch with valid characters",
+			input: "github.com/loft-sh/devpod@feature1",
+			want:  "github-com-loft-sh-devpod",
+		},
+		{
+			name:  "Branch with valid characters and /",
+			input: "github.com/loft-sh/devpod@feat/feature1",
+			want:  "feat-feature1",
+		},
+		{
+			name:  "PR reference",
+			input: "github.com/loft-sh/devpod@pr/123",
+			want:  "pr-123",
+		},
+		{
+			name:  "Truncation beyond 48 characters",
+			input: "github.com/loft-sh/devpodreallylongreponame_that_exceeds_48_characters_total_length",
+			want:  "devpodreallylongreponamethatexceeds48characterst",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToID(tt.input)
+			if got != tt.want {
+				t.Errorf("ToID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- **chore(pro): hide 'try to enable debug logs' line if pro command has been executed by DevPod Desktop.**
- **fix(cli): remove trailing / from workspace source**
