### PR TITLE
Fix kubernetes not resetting sources

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -115,10 +115,15 @@ func (cmd *SetupContainerCmd) Run(ctx context.Context) error {
 	// sync mounts
 	if cmd.StreamMounts {
 		mounts := config.GetMounts(setupInfo)
+		logger.Debug("Syncing mounts... ", mounts)
 		for _, m := range mounts {
-			files, err := os.ReadDir(m.Target)
-			if err == nil && len(files) > 0 {
-				continue
+			// If we are resetting the workspace and it's sources, always re stream the mounts
+			if !workspaceInfo.CLIOptions.Reset {
+				files, err := os.ReadDir(m.Target)
+				if err == nil && len(files) > 0 {
+					logger.Debug("Skip stream mount ", m.Target, " because it's not empty")
+					continue
+				}
 			}
 
 			// stream mount

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -305,11 +305,11 @@ func prepareWorkspace(ctx context.Context, workspaceInfo *provider2.AgentWorkspa
 	if workspaceInfo.Workspace.Source.LocalFolder != "" {
 		// if we're not sending this to a remote machine, we're already done
 		if workspaceInfo.ContentFolder == workspaceInfo.Workspace.Source.LocalFolder {
-			log.Debugf("Local folder with local provider; skip downloading")
+			log.Debugf("Local folder %s with local provider; skip downloading", workspaceInfo.ContentFolder)
 			return nil
 		}
 
-		log.Debugf("Download Local Folder")
+		log.Debugf("Download Local Folder %s", workspaceInfo.ContentFolder)
 		return downloadLocalFolder(ctx, workspaceInfo.ContentFolder, client, log)
 	}
 

--- a/examples/build/Dockerfile
+++ b/examples/build/Dockerfile
@@ -26,6 +26,5 @@ RUN \
     && rm -rf /var/lib/apt/lists/*
 
 COPY app /app
-COPY files /files
 
 RUN echo hello


### PR DESCRIPTION
Fixes - https://github.com/loft-sh/devpod/issues/1072

This issue was that the `devpod agent container setup` command that streams the mounts to the PVC only did so if the mount's target was empty. This indicates an initial set up where we need to copy the local files over. In order to not override changes to the files in the devpod, we only did this when the mount was empty in the workspace (initial setup).

But in the event of a reset, we want the sources to be overridden with the local changes, this flow is common for instance to update to .devcontainer.json. Therefore the fix was to check if the reset option was used and if so, stream the mounts, even if not empty, overriding the workspace contents with the local (source).