### PR TITLE
Update docs for windows dependency

### DIFF
--- a/docs/pages/getting-started/install.mdx
+++ b/docs/pages/getting-started/install.mdx
@@ -43,6 +43,11 @@ Make sure you have the following dependencies installed for the Appimage to work
 Note that these are generally needed for AppImage to work, they are not specific to DevPod
 :::
 
+:::info Windows Packages
+Make sure you have the following dependencies installed for the Desktop App to work:
+
+- [WebView 2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/?form=MA13LH)
+:::
 
 :::info Linux Custom Packages
 Since we're not providing deb or rpm packages anymore, we're now providing a tar.gz

--- a/docs/pages/getting-started/install.mdx
+++ b/docs/pages/getting-started/install.mdx
@@ -47,6 +47,8 @@ Note that these are generally needed for AppImage to work, they are not specific
 Make sure you have the following dependencies installed for the Desktop App to work:
 
 - [WebView 2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/?form=MA13LH)
+
+Note that WebView 2 is normally already installed on recent versions of Windows and should not need installing unless you experience issues.
 :::
 
 :::info Linux Custom Packages


### PR DESCRIPTION
OSS user discovered windows install failed due to missing dependency - https://github.com/loft-sh/devpod/issues/1573

This PR updates the docs to inform users of the required package