### PR TITLE
Refactor runServices upArgs logic

### DIFF
--- a/examples/compose/.devcontainer.json
+++ b/examples/compose/.devcontainer.json
@@ -1,7 +1,7 @@
 {
   "dockerComposeFile": "docker-compose.devcontainer.yml",
   "service": "app",
-  "runServices": ["db", "app2"],
+  "runServices": ["app2"],
   "workspaceFolder": "/workspaces",
   "features":{
     "ghcr.io/devcontainers/features/github-cli:1": {},

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -211,9 +211,9 @@ func (r *runner) runDockerCompose(
 
 // onlyRunServices appends the services defined in .devcontainer.json runServices to the upArgs
 func (r *runner) onlyRunServices(upArgs []string, parsedConfig *config.SubstitutedConfig) []string {
+	// Always run the main devcontainer
+	upArgs = append(upArgs, parsedConfig.Config.Service)
 	if len(parsedConfig.Config.RunServices) > 0 {
-		// Run the main devcontainer
-		upArgs = append(upArgs, parsedConfig.Config.Service)
 		// Run the services defined in .devcontainer.json runServices
 		for _, service := range parsedConfig.Config.RunServices {
 			if service == parsedConfig.Config.Service {

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -165,6 +165,9 @@ func (r *runner) runDockerCompose(
 				upArgs = append(upArgs, "-f", existingProjectFiles)
 			}
 			upArgs = append(upArgs, "up", "-d")
+			upArgs = r.onlyRunServices(upArgs, parsedConfig)
+
+			// Run docker-compose
 			writer := r.Log.Writer(logrus.InfoLevel, false)
 			err = composeHelper.Run(ctx, upArgs, nil, writer, writer)
 			if err != nil {
@@ -204,6 +207,22 @@ func (r *runner) runDockerCompose(
 
 	// setup container
 	return r.setupContainer(ctx, parsedConfig.Raw, containerDetails, mergedConfig, substitutionContext, timeout)
+}
+
+// onlyRunServices appends the services defined in .devcontainer.json runServices to the upArgs
+func (r *runner) onlyRunServices(upArgs []string, parsedConfig *config.SubstitutedConfig) []string {
+	if len(parsedConfig.Config.RunServices) > 0 {
+		// Run the main devcontainer
+		upArgs = append(upArgs, parsedConfig.Config.Service)
+		// Run the services defined in .devcontainer.json runServices
+		for _, service := range parsedConfig.Config.RunServices {
+			if service == parsedConfig.Config.Service {
+				continue
+			}
+			upArgs = append(upArgs, service)
+		}
+	}
+	return upArgs
 }
 
 func (r *runner) getDockerComposeFilePaths(parsedConfig *config.SubstitutedConfig, envFiles []string) ([]string, error) {
@@ -369,16 +388,7 @@ func (r *runner) startContainer(
 	if container != nil {
 		upArgs = append(upArgs, "--no-recreate")
 	}
-
-	if len(parsedConfig.Config.RunServices) > 0 {
-		upArgs = append(upArgs, composeService.Name)
-		for _, service := range parsedConfig.Config.RunServices {
-			if service == composeService.Name {
-				continue
-			}
-			upArgs = append(upArgs, service)
-		}
-	}
+	upArgs = r.onlyRunServices(upArgs, parsedConfig)
 
 	// start compose
 	writer := r.Log.Writer(logrus.InfoLevel, false)


### PR DESCRIPTION
Fixes https://github.com/loft-sh/devpod/issues/1554

The issue was that the initial up logic that ran docker-compose iterated through `runServices` and only added those to the upArgs (line 372). The condition when the container already existed (a re run of up) did not do this (line 167). The fix was to add the same logic to add to upArgs only those services defined by runServices. Additionally I refactored it to a function