### PR TITLE
fix(pro): local folder upload works properly now with pro

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -185,8 +185,12 @@ func decodeWorkspaceInfoAndWrite(
 		}
 	}
 
-	// check content folder
-	if workspaceInfo.Workspace.Source.LocalFolder != "" {
+	// check content folder for local folder workspace source
+	//
+	// We don't want to initialize the content folder with the value of the local workspace folder
+	// if we're running in proxy mode.
+	// We only have write access to /var/lib/loft/* by default causing nearly all local folders to run into permissions issues
+	if workspaceInfo.Workspace.Source.LocalFolder != "" && !workspaceInfo.CLIOptions.Proxy {
 		_, err = os.Stat(workspaceInfo.WorkspaceOrigin)
 		if err == nil {
 			workspaceInfo.ContentFolder = workspaceInfo.Workspace.Source.LocalFolder


### PR DESCRIPTION
The problem was that we correctly put the uploaded local folder under
the workspace directory /var/lib/loft/devpod/$WORKSPACE_ID/agent/.. but
when we established the SSH connection we attempted to create the actual
local workspace folder on the runner side.
Because we usually only have write access to /var/lib/loft remotely this
causes permission issues and `devpod ssh` to fail.
