### PR TITLE
POD-1277 | SSH sessions and proxy full support 

### DIFF
--- a/cmd/agent/container/network_daemon.go
+++ b/cmd/agent/container/network_daemon.go
@@ -43,6 +43,7 @@ func (cmd *NetworkDaemonCmd) Run(_ *cobra.Command, _ []string) error {
 		Host:      tailscale.RemoveProtocol(cmd.PlatformHost),
 		Hostname:  cmd.NetworkHostname,
 		PortHandlers: map[string]func(net.Listener){
+			"8023": tailscale.ReverseProxyHandler("127.0.0.1:8023"),
 			"8022": tailscale.ReverseProxyHandler("127.0.0.1:8022"),
 		},
 	})

--- a/cmd/agent/container/network_daemon.go
+++ b/cmd/agent/container/network_daemon.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/loft-sh/devpod/cmd/flags"
+	sshServer "github.com/loft-sh/devpod/pkg/ssh/server"
 	"github.com/loft-sh/devpod/pkg/tailscale"
 	"github.com/spf13/cobra"
 )
@@ -43,8 +44,8 @@ func (cmd *NetworkDaemonCmd) Run(_ *cobra.Command, _ []string) error {
 		Host:      tailscale.RemoveProtocol(cmd.PlatformHost),
 		Hostname:  cmd.NetworkHostname,
 		PortHandlers: map[string]func(net.Listener){
-			"8023": tailscale.ReverseProxyHandler("127.0.0.1:8023"),
-			"8022": tailscale.ReverseProxyHandler("127.0.0.1:8022"),
+			fmt.Sprintf("%d", sshServer.DefaultPort):     tailscale.ReverseProxyHandler(fmt.Sprintf("127.0.0.1:%d", sshServer.DefaultPort)),
+			fmt.Sprintf("%d", sshServer.DefaultUserPort): tailscale.ReverseProxyHandler(fmt.Sprintf("127.0.0.1:%d", sshServer.DefaultUserPort)),
 		},
 	})
 	if err := tsNet.Start(context.TODO()); err != nil {

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -234,7 +234,7 @@ func (cmd *SetupContainerCmd) Run(ctx context.Context) error {
 				return nil, err
 			}
 
-			return exec.Command(binaryPath, "helper", "ssh-server"), nil
+			return exec.Command(binaryPath, "helper", "ssh-server", "--track-activity"), nil
 		})
 		if err != nil {
 			return err

--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -127,6 +127,10 @@ func StartSSHSession(ctx context.Context, user, command string, agentForwarding 
 	}
 	defer sshClient.Close()
 
+	return RunSSHSession(ctx, sshClient, agentForwarding, command, stderr)
+}
+
+func RunSSHSession(ctx context.Context, sshClient *ssh.Client, agentForwarding bool, command string, stderr io.Writer) error {
 	// create a new session
 	session, err := sshClient.NewSession()
 	if err != nil {

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -4,11 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,10 +25,11 @@ import (
 	"github.com/loft-sh/devpod/pkg/devcontainer"
 	dpFlags "github.com/loft-sh/devpod/pkg/flags"
 	"github.com/loft-sh/devpod/pkg/gpg"
-	"github.com/loft-sh/devpod/pkg/platform/client"
+	"github.com/loft-sh/devpod/pkg/platform"
 	"github.com/loft-sh/devpod/pkg/port"
 	"github.com/loft-sh/devpod/pkg/provider"
 	devssh "github.com/loft-sh/devpod/pkg/ssh"
+	sshServer "github.com/loft-sh/devpod/pkg/ssh/server"
 	"github.com/loft-sh/devpod/pkg/tailscale"
 	"github.com/loft-sh/devpod/pkg/tunnel"
 	workspace2 "github.com/loft-sh/devpod/pkg/workspace"
@@ -39,7 +38,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/term"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
@@ -162,7 +160,11 @@ func (cmd *SSHCmd) Run(
 	}
 
 	if cmd.UseTailscale {
-		return cmd.startTailscaleTunnel(ctx, devPodConfig, client, log)
+		proxyClient, ok := client.(client2.ProxyClient)
+		if !ok {
+			return fmt.Errorf("tailscale is only accessible to DevPod Pro workspaces")
+		}
+		return cmd.startTSProxyTunnel(ctx, devPodConfig, proxyClient, log)
 	}
 
 	// check if regular workspace client
@@ -201,72 +203,249 @@ func (cmd *SSHCmd) startProxyTunnel(
 		},
 	)
 }
-func (cmd *SSHCmd) startTailscaleTunnel(
+
+func (cmd *SSHCmd) startTSProxyTunnel(
 	ctx context.Context,
 	devPodConfig *config.Config,
-	client client2.BaseWorkspaceClient,
+	client client2.ProxyClient,
 	log log.Logger,
 ) error {
-	log.Infof("Starting Tailscale connection")
+	log.Debugf("Starting proxy connection")
+
 	if cmd.Provider == "" {
 		cmd.Provider = devPodConfig.Current().DefaultProvider
 	}
 
-	config, err := readConfig(cmd.Context, cmd.Provider)
+	// Load configuration
+	config, err := platform.ReadConfig(cmd.Context, cmd.Provider)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read devpod configuration: %w", err)
 	}
 
-	osHostname, err := os.Hostname()
+	// Get client hostname
+	hostname, err := tailscale.GetHostname()
 	if err != nil {
-		fmt.Printf("Failed to get hostname: %v\n", err)
-		return err
+		return fmt.Errorf("failed to get hostname: %w", err)
 	}
-	osHostname = strings.ReplaceAll(osHostname, ".", "-")
 
+	// Initialize Tailscale network
 	network := tailscale.NewTSNet(&tailscale.TSNetConfig{
-		AccessKey:    config.AccessKey,
-		Host:         tailscale.RemoveProtocol(config.Host),
-		Hostname:     fmt.Sprintf("devpod.%v.client", osHostname),
-		LogF:         func(format string, args ...any) {}, // No-op logger
-		PortHandlers: map[string]func(net.Listener){},
+		AccessKey: config.AccessKey,
+		Host:      tailscale.RemoveProtocol(config.Host),
+		Hostname:  hostname,
+		LogF:      func(format string, args ...any) {},
 	})
 
-	// Start TSNet in a separate goroutine
+	// Start Tailscale network
 	startCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	errChan := make(chan error, 1)
 	go func() {
-		err := network.Start(startCtx)
-		if err != nil {
-			errChan <- fmt.Errorf("failed to start TSNet: %w", err)
+		if err := network.Start(startCtx); err != nil {
+			log.Errorf("failed to start TSNet: %v", err)
+			cancel()
 		}
-		close(errChan)
 	}()
+
 	// Wait for the host to become reachable
 	reachableHost := fmt.Sprintf(
 		"devpod.%v.%v.test.workspace",
 		client.WorkspaceConfig().Pro.DisplayName,
 		client.WorkspaceConfig().Pro.Project,
 	)
-	waitUntilReachable(ctx, network, reachableHost, log)
+	if err := waitUntilReachable(ctx, network, reachableHost, log); err != nil {
+		return fmt.Errorf("failed to reach TSNet host: %w", err)
+	}
 
-	log.Infof("Host %s is reachable. Proceeding with SSH session...", reachableHost)
-	return cmd.StartSSHSession(ctx, network, reachableHost, cmd.User, "", devPodConfig, client, log)
+	log.Debugf("Host %s is reachable. Proceeding with SSH session...", reachableHost)
+
+	return runTSTunnel(
+		ctx,
+		network,
+		reachableHost,
+		cmd,
+		devPodConfig,
+		client,
+		log,
+	)
+}
+
+// TODO: move this to pkg/tunnel
+func runTSTunnel(
+	ctx context.Context,
+	network tailscale.TSNet,
+	host string,
+	cmd *SSHCmd, // FIXME: ???
+	devPodConfig *config.Config,
+	workspaceClient client2.ProxyClient,
+	log log.Logger,
+) error {
+	return establishOuterTunnel(ctx, network, host, log, func(outerSshClient *ssh.Client) error {
+		log.Debugf("Outer tunnel established. Starting inner server...")
+
+		// Start the inner SSH server
+		if err := startInnerServer(outerSshClient, cmd.User, cmd.WorkDir, log); err != nil {
+			log.Errorf("Failed to start inner SSH server: %v", err)
+			return fmt.Errorf("failed to start inner SSH server: %w", err)
+		}
+
+		// Wait for the inner server to be reachable
+		// FIXME: Ensure this works correctly, considering the reverse proxy server on this port.
+		if err := waitForInnerServer(ctx, network, host, sshServer.DefaultUserPort); err != nil {
+			log.Errorf("Inner server not reachable: %v", err)
+			return fmt.Errorf("inner SSH server not reachable: %w", err)
+		}
+
+		log.Debugf("Inner server reachable. Establishing user session...")
+
+		// Create an SSH client for the inner server
+		sshClient, err := devssh.TailscaleClientWithUser(
+			ctx, network, tailscale.GetURL(host, sshServer.DefaultUserPort), cmd.User, log)
+		if err != nil {
+			return fmt.Errorf("failed to create SSH client for inner server: %w", err)
+		}
+		defer sshClient.Close()
+
+		// Forward ports if specified
+		if len(cmd.ForwardPorts) > 0 {
+			return cmd.forwardPorts(ctx, outerSshClient, log)
+		}
+
+		// Reverse forward ports if specified
+		if len(cmd.ReverseForwardPorts) > 0 && !cmd.GPGAgentForwarding {
+			return cmd.reverseForwardPorts(ctx, outerSshClient, log)
+		}
+
+		// Start port-forwarding and services if enabled
+		if cmd.StartServices {
+			go cmd.startServices(ctx, devPodConfig, outerSshClient, cmd.GitUsername, cmd.GitToken, workspaceClient.WorkspaceConfig(), log)
+		}
+
+		// Handle GPG agent forwarding
+		if cmd.GPGAgentForwarding || devPodConfig.ContextOption(config.ContextOptionGPGAgentForwarding) == "true" {
+			if gpg.IsGpgTunnelRunning(cmd.User, ctx, sshClient, log) {
+				log.Debugf("[GPG] exporting already running, skipping")
+			} else if err := cmd.setupGPGAgent(ctx, sshClient, log); err != nil {
+				return err
+			}
+		}
+
+		// Retrieve environment variables
+		// envVars, err := cmd.retrieveEnVars()
+		// if err != nil {
+		// 	return err
+		// }
+
+		// Handle ssh remote proxy mode
+		if cmd.Stdio {
+			if cmd.SSHKeepAliveInterval != DisableSSHKeepAlive {
+				go startSSHKeepAlive(ctx, outerSshClient, cmd.SSHKeepAliveInterval, log)
+			}
+
+			go func() {
+				if err := cmd.startRunnerServices(ctx, devPodConfig, outerSshClient, log); err != nil {
+					log.Error(err)
+				}
+			}()
+
+			go func() {
+				cmd.setupPlatformAccess(ctx, sshClient, log) // FIXME: for whatever reason this doesn't work but when running command from inside the container it works just fine
+			}()
+
+			return tailscale.DirectTunnel(ctx, network, host, sshServer.DefaultUserPort, os.Stdin, os.Stdout)
+		}
+
+		// Connect to the inner server and handle user session
+		return machine.RunSSHSession(
+			ctx,
+			sshClient,
+			cmd.AgentForwarding,
+			cmd.Command,
+			os.Stderr,
+		)
+	})
+}
+
+// establishOuterTunnel establishes the root-level connection.
+func establishOuterTunnel(ctx context.Context, network tailscale.TSNet, host string, log log.Logger, onReady func(*ssh.Client) error) error {
+	log.Debugf("Estabilishing outer connection")
+	address := tailscale.GetURL(host, sshServer.DefaultPort)
+	conn, err := network.Dial(ctx, "tcp", address)
+	if err != nil {
+		return fmt.Errorf("failed to connect to outer tunnel: %w", err)
+	}
+	defer conn.Close()
+
+	sshConfig := &ssh.ClientConfig{
+		User:            "root",
+		Auth:            []ssh.AuthMethod{},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	clientConn, chans, reqs, err := ssh.NewClientConn(conn, address, sshConfig)
+	if err != nil {
+		return fmt.Errorf("failed to establish SSH connection: %w", err)
+	}
+	client := ssh.NewClient(clientConn, chans, reqs)
+	defer client.Close()
+
+	log.Debugf("Outer connection ready")
+	return onReady(client)
+}
+
+// startInnerServer starts the user-level SSH server.
+func startInnerServer(sshClient *ssh.Client, user, workDir string, log log.Logger) error {
+	command := fmt.Sprintf(
+		"/usr/local/bin/devpod helper ssh-server --workdir '%s' --address 0.0.0.0:%d",
+		workDir, sshServer.DefaultUserPort,
+	)
+	// if user != "root" {
+	// 	command = fmt.Sprintf("su -c \"%s\" '%s'", command, user)
+	// }
+
+	session, err := sshClient.NewSession()
+	if err != nil {
+		return fmt.Errorf("failed to create SSH session: %w", err)
+	}
+	defer session.Close()
+
+	var stderr bytes.Buffer
+	session.Stderr = &stderr
+
+	if err := session.Run(command); err != nil {
+		return fmt.Errorf("inner server start failed: %w (stderr: %s)", err, stderr.String())
+	}
+
+	return nil
+}
+
+// waitForInnerServer waits for the inner server to become reachable.
+func waitForInnerServer(ctx context.Context, network tailscale.TSNet, host string, port int) error {
+	address := tailscale.GetURL(host, port)
+	deadline := time.Now().Add(10 * time.Second)
+
+	for time.Now().Before(deadline) {
+		conn, err := network.Dial(ctx, "tcp", address)
+		if err == nil {
+			conn.Close()
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return fmt.Errorf("inner server not reachable at %s", address)
 }
 
 // waitUntilReachable polls until the given host is reachable via Tailscale.
 func waitUntilReachable(ctx context.Context, ts tailscale.TSNet, host string, log log.Logger) error {
-	const retryInterval = time.Second
+	const retryInterval = 100 * time.Millisecond
 	const maxRetries = 60
 
 	for i := 0; i < maxRetries; i++ {
-		conn, err := ts.Dial(ctx, "tcp", fmt.Sprintf("%s.ts.loft:8022", host))
+		conn, err := ts.Dial(ctx, "tcp", tailscale.GetURL(host, sshServer.DefaultPort))
 		if err == nil {
 			_ = conn.Close()
 			return nil // Host is reachable
 		}
-		log.Infof("Host %s not reachable, retrying... (%d/%d)", host, i+1, maxRetries)
+		log.Debugf("Host %s not reachable, retrying... (%d/%d)", host, i+1, maxRetries)
 
 		select {
 		case <-ctx.Done():
@@ -276,120 +455,6 @@ func waitUntilReachable(ctx context.Context, ts tailscale.TSNet, host string, lo
 	}
 
 	return fmt.Errorf("host %s not reachable after %d attempts", host, maxRetries)
-}
-
-const (
-	LoftPlatformConfigFileName = "loft-config.json" // TODO: move somewhere else, replace hardoced strings with usage of this const
-)
-
-func readConfig(contextName string, providerName string) (*client.Config, error) {
-	if contextName == "" {
-
-	}
-	providerDir, err := provider.GetProviderDir(contextName, providerName)
-	if err != nil {
-		return nil, err
-	}
-
-	configPath := filepath.Join(providerDir, LoftPlatformConfigFileName)
-
-	// Check if given context and provider have Loft Platform configuration
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		// If not just return empty response
-		return &client.Config{}, nil
-	}
-
-	content, err := os.ReadFile(configPath)
-	if err != nil {
-		return nil, err
-	}
-
-	loftConfig := &client.Config{}
-	err = json.Unmarshal(content, loftConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return loftConfig, nil
-}
-
-const loftTSNetDomain = "ts.loft"
-
-// StartSSHSession establishes an SSH session over tsnet.
-func (cmd *SSHCmd) StartSSHSession(
-	ctx context.Context,
-	ts tailscale.TSNet,
-	addr, username, password string,
-	devPodConfig *config.Config,
-	workspaceClient client2.BaseWorkspaceClient,
-	log log.Logger,
-) error {
-	workdir := filepath.Join("/workspaces", workspaceClient.Workspace())
-	if cmd.WorkDir != "" {
-		workdir = cmd.WorkDir
-	}
-
-	clientConfig := &ssh.ClientConfig{
-		User: username,
-		Auth: []ssh.AuthMethod{
-			ssh.Password(password), // FIXME - use keys
-		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // FIXME
-	}
-
-	// Dial the SSH server through TSNet
-	serverAddress := fmt.Sprintf("%v.%v:8022", addr, loftTSNetDomain) // FIXME
-	conn, err := ts.Dial(ctx, "tcp", serverAddress)
-	if err != nil {
-		return fmt.Errorf("failed to connect to %s: %w", serverAddress, err)
-	}
-	defer conn.Close()
-
-	// Establish an SSH client connection
-	sshConn, channels, requests, err := ssh.NewClientConn(conn, serverAddress, clientConfig)
-	if err != nil {
-		return fmt.Errorf("failed to establish SSH connection: %w", err)
-	}
-	client := ssh.NewClient(sshConn, channels, requests)
-	defer client.Close()
-
-	// Start an SSH session
-	session, err := client.NewSession()
-	if err != nil {
-		return fmt.Errorf("failed to create SSH session: %w", err)
-	}
-	defer session.Close()
-
-	// Configure terminal for interactive shell
-	fd := int(os.Stdin.Fd())
-	if term.IsTerminal(fd) {
-		oldState, err := term.MakeRaw(fd)
-		if err != nil {
-			return fmt.Errorf("failed to set terminal raw mode: %w", err)
-		}
-		defer term.Restore(fd, oldState)
-
-		session.Stdout = os.Stdout
-		session.Stderr = os.Stderr
-		session.Stdin = os.Stdin
-
-		termModes := ssh.TerminalModes{
-			ssh.ECHO:          1,
-			ssh.TTY_OP_ISPEED: 14400,
-			ssh.TTY_OP_OSPEED: 14400,
-		}
-		err = session.RequestPty("xterm", 80, 24, termModes)
-		if err != nil {
-			return fmt.Errorf("failed to request PTY: %w", err)
-		}
-
-		err = session.Run(fmt.Sprintf("cd %s; exec $SHELL --noediting -i", workdir))
-		if err != nil {
-			return fmt.Errorf("failed to start shell: %w", err)
-		}
-	}
-
-	return nil
 }
 
 func startWait(
@@ -649,7 +714,7 @@ func (cmd *SSHCmd) startTunnel(ctx context.Context, devPodConfig *config.Config,
 	}
 
 	log.Debugf("Run outer container tunnel")
-	command := fmt.Sprintf("'%s' helper ssh-server --track-activity --stdio --workdir '%s'", agent.ContainerDevPodHelperLocation, workdir)
+	command := fmt.Sprintf("'%s' helper ssh-server --track-activity --workdir '%s'", agent.ContainerDevPodHelperLocation, workdir)
 	if cmd.ReuseSSHAuthSock != "" {
 		log.Debug("Reusing SSH_AUTH_SOCK")
 		command += fmt.Sprintf(" --reuse-ssh-auth-sock=%s", cmd.ReuseSSHAuthSock)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -177,9 +177,6 @@ func (cmd *UpCmd) Run(
 		log.Debug("Reusing SSH_AUTH_SOCK is not supported with proxy mode, consider launching the IDE from the platform UI")
 	}
 
-	log.Infof("DEBUG -> GOT %v hostname %v platform %v", cmd.AccessKey, cmd.NetworkHostname, cmd.PlatformHost)
-	log.Infof("DEBUG -> BUT on devpodconfig object -> %v", client.WorkspaceConfig())
-
 	// run devpod agent up
 	result, err := cmd.devPodUp(ctx, devPodConfig, client, log)
 	if err != nil {

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -107,7 +107,7 @@ func (r *runner) setupContainer(
 
 	// setup container
 	r.Log.Infof("Setup container...")
-	r.Log.Infof("GOT ACCESS KEY HOSTNAME AND HOST -> %s %s %s", r.WorkspaceConfig.CLIOptions.AccessKey, r.WorkspaceConfig.CLIOptions.NetworkHostname, r.WorkspaceConfig.CLIOptions.PlatformHost)
+
 	setupCommand := fmt.Sprintf(
 		"'%s' agent container setup --setup-info '%s' --container-workspace-info '%s' --access-key '%s' --network-hostname '%s'",
 		agent.ContainerDevPodHelperLocation,

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -1,12 +1,18 @@
 package platform
 
 import (
+	"encoding/json"
 	"os"
+	"path/filepath"
 	"time"
+
+	"github.com/loft-sh/devpod/pkg/platform/client"
+	"github.com/loft-sh/devpod/pkg/provider"
 )
 
 const (
-	defaultTimeout = 10 * time.Minute
+	defaultTimeout                    = 10 * time.Minute
+	LoftPlatformConfigFileName string = "loft-config.json" // TODO: replace hardcoded strings with this
 )
 
 func Timeout() time.Duration {
@@ -17,4 +23,36 @@ func Timeout() time.Duration {
 	}
 
 	return defaultTimeout
+}
+
+// ReadConfig reads client.Config for given context and provider
+func ReadConfig(contextName string, providerName string) (*client.Config, error) {
+	if contextName == "" {
+
+	}
+	providerDir, err := provider.GetProviderDir(contextName, providerName)
+	if err != nil {
+		return nil, err
+	}
+
+	configPath := filepath.Join(providerDir, LoftPlatformConfigFileName)
+
+	// Check if given context and provider have Loft Platform configuration
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		// If not just return empty response
+		return &client.Config{}, nil
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	loftConfig := &client.Config{}
+	err = json.Unmarshal(content, loftConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return loftConfig, nil
 }

--- a/pkg/ssh/helper.go
+++ b/pkg/ssh/helper.go
@@ -6,6 +6,8 @@ import (
 	"io"
 
 	"github.com/loft-sh/devpod/pkg/stdio"
+	"github.com/loft-sh/devpod/pkg/tailscale"
+	"github.com/loft-sh/log"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 )
@@ -54,6 +56,33 @@ func StdioClient(reader io.Reader, writer io.WriteCloser, exitOnClose bool) (*ss
 
 func StdioClientWithUser(reader io.Reader, writer io.WriteCloser, user string, exitOnClose bool) (*ssh.Client, error) {
 	return StdioClientFromKeyBytesWithUser(nil, reader, writer, user, exitOnClose)
+}
+
+func TailscaleClientWithUser(ctx context.Context, ts tailscale.TSNet, serverAddress, user string, log log.Logger) (*ssh.Client, error) {
+	log.Debugf("Connecting to SSH server at %s with user %s", serverAddress, user)
+
+	conn, err := ts.Dial(ctx, "tcp", serverAddress)
+	if err != nil {
+		log.Errorf("Failed to connect to %s: %v", serverAddress, err)
+		return nil, fmt.Errorf("failed to connect to %s: %w", serverAddress, err)
+	}
+
+	clientConfig := &ssh.ClientConfig{
+		User:            user,
+		Auth:            []ssh.AuthMethod{}, // FIXME
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	log.Debugf("Attempting to establish SSH connection with %s as user %s", serverAddress, user)
+
+	sshConn, channels, requests, err := ssh.NewClientConn(conn, serverAddress, clientConfig)
+	if err != nil {
+		log.Errorf("Failed to establish SSH connection to %s: %v", serverAddress, err)
+		return nil, fmt.Errorf("failed to establish SSH connection: %w", err)
+	}
+
+	log.Debugf("SSH connection established with %s as user %s", serverAddress, user)
+	return ssh.NewClient(sshConn, channels, requests), nil
 }
 
 func StdioClientFromKeyBytesWithUser(keyBytes []byte, reader io.Reader, writer io.WriteCloser, user string, exitOnClose bool) (*ssh.Client, error) {

--- a/pkg/ssh/server/ssh.go
+++ b/pkg/ssh/server/ssh.go
@@ -22,7 +22,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var DefaultPort = 8022
+const (
+	DefaultPort     int = 8022
+	DefaultUserPort int = 12023
+)
 
 func NewServer(addr string, hostKey []byte, keys []ssh.PublicKey, workdir string, reuseSock string, log log.Logger) (*Server, error) {
 	sh, err := shell.GetShell("")


### PR DESCRIPTION
Fixes POD-1277

Example container state when running workspace

```
root ➜ /go $ ps -aux --forest
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         549  0.0  0.0   7616  6832 pts/4    Ss   13:45   0:00 bash
root         644  0.0  0.0   8160  3948 pts/4    R+   13:46   0:00  \_ ps -aux --forest
root           1  0.0  0.0   2316  1184 ?        Ss   13:45   0:00 /bin/sh -c echo Container started trap "exit 0" 15  exec "$@" while sleep 1 & wai
root         107  1.2  0.5 1328728 90264 ?       Sl   13:45   0:00 /usr/local/bin/devpod agent container network-daemon --access-key n2Z5MHx3EJRoFGf
root         115  0.7  0.4 1328216 72484 ?       Sl   13:45   0:00 /usr/local/bin/devpod helper ssh-server --track-activity
root         142  0.6  0.4 1327960 71172 ?       Sl   13:45   0:00  \_ /usr/local/bin/devpod helper ssh-server --workdir  --address 0.0.0.0:12023
root         193  0.0  0.0   5096  2392 ?        S    13:45   0:00  |   \_ su vscode
vscode       195  0.0  0.0   3788  2716 ?        S    13:45   0:00  |       \_ bash
vscode       202  0.0  0.0   2420  1428 ?        S    13:45   0:00  |           \_ sh
vscode       275 15.2  0.0  49352 15756 ?        Sl   13:45   0:01  |               \_ /home/vscode/.vscode-server/code-fabdb6a30b49f79a7aba0f2ad9df
vscode       325  0.0  0.0   2316  1364 ?        S    13:45   0:00  |               |   \_ sh /home/vscode/.vscode-server/cli/servers/Stable-fabdb6a
vscode       329 11.4  0.7 5285044 129456 ?      Sl   13:45   0:01  |               |       \_ /home/vscode/.vscode-server/cli/servers/Stable-fabdb6
vscode       367 16.6  0.7 13689456 116012 ?     Sl   13:45   0:01  |               |           \_ /home/vscode/.vscode-server/cli/servers/Stable-fa
vscode       378  0.8  0.3 5171244 51064 ?       Sl   13:45   0:00  |               |           \_ /home/vscode/.vscode-server/cli/servers/Stable-fa
vscode       391  1.9  0.3 5067124 60552 ?       Sl   13:45   0:00  |               |           \_ /home/vscode/.vscode-server/cli/servers/Stable-fa
vscode       305  0.0  0.0   2216  1148 ?        S    13:45   0:00  |               \_ sleep 180
root         180  0.2  0.4 1327704 67916 ?       Sl   13:45   0:00  \_ /usr/local/bin/devpod agent container credentials-server --user vscode --conf
root         194  0.2  0.4 1327960 68496 ?       Sl   13:45   0:00  \_ /usr/local/bin/devpod agent container credentials-server --user vscode --conf
root         643  0.0  0.0   2216  1148 ?        S    13:46   0:00 sleep 1
```