### PR TITLE
chore(security): add context option to set StrictHostKeyChecking to yes for ssh based git operations

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -570,14 +570,14 @@ func configureSystemGitCredentials(ctx context.Context, cancel context.CancelFun
 	gitCredentials := fmt.Sprintf("!'%s' agent git-credentials --port %d", binaryPath, serverPort)
 	_ = os.Setenv("DEVPOD_GIT_HELPER_PORT", strconv.Itoa(serverPort))
 
-	err = git.CommandContext(ctx, "config", "--system", "--add", "credential.helper", gitCredentials).Run()
+	err = git.CommandContext(ctx, git.GitCommandOptions{}, "config", "--system", "--add", "credential.helper", gitCredentials).Run()
 	if err != nil {
 		return nil, fmt.Errorf("add git credential helper: %w", err)
 	}
 
 	cleanup := func() {
 		log.Debug("Unset setup system credential helper")
-		err = git.CommandContext(ctx, "config", "--system", "--unset", "credential.helper").Run()
+		err = git.CommandContext(ctx, git.GitCommandOptions{}, "config", "--system", "--unset", "credential.helper").Run()
 		if err != nil {
 			log.Errorf("unset system credential helper %v", err)
 		}

--- a/cmd/agent/workspace/install_dotfiles.go
+++ b/cmd/agent/workspace/install_dotfiles.go
@@ -19,8 +19,9 @@ import (
 type InstallDotfilesCmd struct {
 	*flags.GlobalFlags
 
-	Repository    string
-	InstallScript string
+	Repository            string
+	InstallScript         string
+	StrictHostKeyChecking bool
 }
 
 // NewInstallDotfilesCmd creates a new command
@@ -38,6 +39,7 @@ func NewInstallDotfilesCmd(flags *flags.GlobalFlags) *cobra.Command {
 	}
 	installDotfilesCmd.Flags().StringVar(&cmd.Repository, "repository", "", "The dotfiles repository")
 	installDotfilesCmd.Flags().StringVar(&cmd.InstallScript, "install-script", "", "The dotfiles install command to execute")
+	installDotfilesCmd.Flags().BoolVar(&cmd.StrictHostKeyChecking, "strict-host-key-checking", false, "Set to enable strict host key checking for git cloning via SSH")
 	return installDotfilesCmd
 }
 
@@ -51,8 +53,9 @@ func (cmd *InstallDotfilesCmd) Run(ctx context.Context) error {
 		logger.Infof("Cloning dotfiles %s", cmd.Repository)
 
 		gitInfo := git.NormalizeRepositoryGitInfo(cmd.Repository)
+		gitOpts := git.GitCommandOptions{StrictHostKeyChecking: cmd.StrictHostKeyChecking}
 
-		if err := git.CloneRepository(ctx, gitInfo, targetDir, "", nil, logger); err != nil {
+		if err := git.CloneRepository(ctx, gitInfo, targetDir, gitOpts, "", nil, logger); err != nil {
 			return err
 		}
 	} else {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -61,6 +61,10 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 				}
 			}
 
+			if devPodConfig.ContextOption(config.ContextOptionSSHStrictHostKeyChecking) == "true" {
+				cmd.StrictHostKeyChecking = true
+			}
+
 			// create a temporary workspace
 			exists := workspace2.Exists(ctx, devPodConfig, args, "", log.Default)
 			sshConfigFile, err := os.CreateTemp("", "devpodssh.config")

--- a/pkg/agent/tunnel/tunnel.proto
+++ b/pkg/agent/tunnel/tunnel.proto
@@ -20,7 +20,6 @@ service Tunnel {
   rpc ForwardPort(ForwardPortRequest) returns (ForwardPortResponse) {}
   rpc StopForwardPort(StopForwardPortRequest) returns (StopForwardPortResponse) {}
 
-  rpc StreamGitClone(Empty) returns (stream Chunk) {}
   rpc StreamWorkspace(Empty) returns (stream Chunk) {}
   rpc StreamMount(StreamMountRequest) returns (stream Chunk) {}
 }

--- a/pkg/agent/tunnelserver/proxyserver.go
+++ b/pkg/agent/tunnelserver/proxyserver.go
@@ -134,23 +134,6 @@ func (t *proxyServer) Log(ctx context.Context, message *tunnel.LogMessage) (*tun
 	return t.client.Log(ctx, message)
 }
 
-func (t *proxyServer) StreamGitClone(message *tunnel.Empty, stream tunnel.Tunnel_StreamGitCloneServer) error {
-	t.log.Debug("Cloning and reading workspace")
-	client, err := t.client.StreamGitClone(context.TODO(), &tunnel.Empty{})
-	if err != nil {
-		return err
-	}
-
-	buf := bufio.NewWriterSize(NewStreamWriter(stream, t.log), 10*1024)
-	_, err = io.Copy(buf, NewStreamReader(client, t.log))
-	if err != nil {
-		return err
-	}
-
-	// make sure buffer is flushed
-	return buf.Flush()
-}
-
 func (t *proxyServer) StreamWorkspace(message *tunnel.Empty, stream tunnel.Tunnel_StreamWorkspaceServer) error {
 	t.log.Debug("Start reading workspace")
 

--- a/pkg/agent/workspace.go
+++ b/pkg/agent/workspace.go
@@ -297,7 +297,8 @@ func CloneRepositoryForWorkspace(
 	// run git command
 	cloner := git.NewClonerWithOpts(getGitOptions(options)...)
 	gitInfo := git.NewGitInfo(source.GitRepository, source.GitBranch, source.GitCommit, source.GitPRReference, source.GitSubPath)
-	err := git.CloneRepositoryWithEnv(ctx, gitInfo, extraEnv, workspaceDir, helper, cloner, log)
+	gitOpts := git.GitCommandOptions{StrictHostKeyChecking: options.StrictHostKeyChecking}
+	err := git.CloneRepositoryWithEnv(ctx, gitInfo, extraEnv, workspaceDir, gitOpts, helper, cloner, log)
 	if err != nil {
 		// cleanup workspace dir if clone failed, otherwise we won't try to clone again when rebuilding this workspace
 		if cleanupErr := cleanupWorkspaceDir(workspaceDir); cleanupErr != nil {

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -21,6 +21,7 @@ const (
 	ContextOptionSSHConfigPath              = "SSH_CONFIG_PATH"
 	ContextOptionAgentInjectTimeout         = "AGENT_INJECT_TIMEOUT"
 	ContextOptionRegistryCache              = "REGISTRY_CACHE"
+	ContextOptionSSHStrictHostKeyChecking   = "SSH_STRICT_HOST_KEY_CHECKING"
 )
 
 var ContextOptions = []ContextOption{
@@ -97,6 +98,12 @@ var ContextOptions = []ContextOption{
 		Name:        ContextOptionRegistryCache,
 		Description: "Specifies the registry to use as a build cache, e.g. gcr.io/my-project/my-dev-env",
 		Default:     "",
+	},
+	{
+		Name:        ContextOptionSSHStrictHostKeyChecking,
+		Description: "Enables strict ssh host key checking for all operations",
+		Default:     "false",
+		Enum:        []string{"true", "false"},
 	},
 }
 

--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -22,7 +22,7 @@ const (
 )
 
 type Cloner interface {
-	Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, log log.Logger) error
+	Clone(ctx context.Context, repository string, targetDir string, gitOpts GitCommandOptions, extraArgs, extraEnv []string, log log.Logger) error
 }
 
 type Option func(*cloner)
@@ -100,20 +100,20 @@ func (c *cloner) initialArgs() []string {
 	return []string{"clone"}
 }
 
-func (c *cloner) Clone(ctx context.Context, repository string, targetDir string, extraArgs, extraEnv []string, log log.Logger) error {
+func (c *cloner) Clone(ctx context.Context, repository string, targetDir string, gitOpts GitCommandOptions, extraArgs, extraEnv []string, log log.Logger) error {
 	args := c.initialArgs()
 	args = append(args, extraArgs...)
 	args = append(args, c.extraArgs...)
 	args = append(args, repository, targetDir)
-	return run(ctx, args, extraEnv, log)
+	return run(ctx, args, gitOpts, extraEnv, log)
 }
 
-func run(ctx context.Context, args []string, extraEnv []string, log log.Logger) error {
+func run(ctx context.Context, args []string, gitOpts GitCommandOptions, extraEnv []string, log log.Logger) error {
 	var buf bytes.Buffer
 
 	args = append(args, "--progress")
 
-	gitCommand := CommandContext(ctx, args...)
+	gitCommand := CommandContext(ctx, gitOpts, args...)
 	gitCommand.Stdout = &buf
 	gitCommand.Stderr = &buf
 	gitCommand.Env = append(gitCommand.Env, extraEnv...)

--- a/pkg/gitcredentials/gitcredentials.go
+++ b/pkg/gitcredentials/gitcredentials.go
@@ -216,7 +216,7 @@ func GetCredentials(requestObj *GitCredentials) (*GitCredentials, error) {
 	}
 
 	// use local credentials if not
-	c := git.CommandContext(context.TODO(), "credential", "fill")
+	c := git.CommandContext(context.TODO(), git.GitCommandOptions{}, "credential", "fill")
 	c.Stdin = strings.NewReader(ToString(requestObj))
 	stdout, err := c.Output()
 	if err != nil {
@@ -244,7 +244,7 @@ func GetHTTPPath(ctx context.Context, params GetHttpPathParameters) (string, err
 	// The actual format for the key is `credential.$PROTOCOL://$HOST.useHttpPath`, i.e. `credential.https://github.com.useHttpPath`
 	// We need to ignore the error as git will always exit with 1 if the key doesn't exist
 	configKey := fmt.Sprintf("credential.%s://%s.useHttpPath", params.Protocol, params.Host)
-	out, _ := git.CommandContext(ctx, "config", "--get", configKey).Output()
+	out, _ := git.CommandContext(ctx, git.GitCommandOptions{}, "config", "--get", configKey).Output()
 	if strings.TrimSpace(string(out)) != "true" {
 		return "", nil
 	}

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -220,6 +220,7 @@ type CLIOptions struct {
 	FallbackImage               string            `json:"fallbackImage,omitempty"`
 	GitSSHSigningKey            string            `json:"gitSshSigningKey,omitempty"`
 	SSHAuthSockID               string            `json:"sshAuthSockID,omitempty"` // ID to use when looking for SSH_AUTH_SOCK, defaults to a new random ID if not set (only used for browser IDEs)
+	StrictHostKeyChecking       bool              `json:"strictHostKeyChecking,omitempty"`
 
 	// build options
 	Repository string   `json:"repository,omitempty"`


### PR DESCRIPTION
Enables users to set the `SSH_STRICT_HOST_KEY_CHECKING` context option to tighten security for ssh based git clones