### PR TITLE
docs: Add a Fedora package name to install doc

### DIFF
--- a/docs/pages/getting-started/install.mdx
+++ b/docs/pages/getting-started/install.mdx
@@ -69,6 +69,8 @@ correct functioning of the program:
 - libwebkit2gtk-4.0-37
 - librust-openssl-sys-dev
 - librust-glib-sys-dev
+
+On Fedora: `sudo dnf install libappindicator-gtk3`
 :::
 
 ## Install DevPod CLI


### PR DESCRIPTION
This is useful to workaround #1410.