### PR TITLE
doc: remove equinix provider (#2)

### DIFF
--- a/community.yaml
+++ b/community.yaml
@@ -2,7 +2,6 @@ providers:
   - repository: https://github.com/alexandrevilain/devpod-provider-ovhcloud
   - repository: https://github.com/dirien/devpod-provider-exoscale
   - repository: https://github.com/dirien/devpod-provider-scaleway
-  - repository: https://github.com/dirien/devpod-provider-equinix
   - repository: https://github.com/mrsimonemms/devpod-provider-hetzner
   - repository: https://github.com/cloudbit-ch/devpod-provider-cloudbit
   - repository: https://github.com/flowswiss/devpod-provider-flow

--- a/docs/pages/managing-providers/add-provider.mdx
+++ b/docs/pages/managing-providers/add-provider.mdx
@@ -230,7 +230,6 @@ The community maintains providers for additional services.
 - [Hetzner (mrsimonemms/devpod-provider-hetzner)](https://github.com/mrsimonemms/devpod-provider-hetzner)
 - [OVHcloud (alexandrevilain/devpod-provider-ovhcloud)](https://github.com/alexandrevilain/devpod-provider-ovhcloud)
 - [Scaleway (dirien/devpod-provider-scaleway)](https://github.com/dirien/devpod-provider-scaleway)
-- [Equinix (dirien/devpod-provider-equinix)](https://github.com/dirien/devpod-provider-equinix)
 - [Exoscale (dirien/devpod-provider-exoscale)](https://github.com/dirien/devpod-provider-exoscale)
 - [Multipass (minhio/devpod-provider-multipass)](https://github.com/minhio/devpod-provider-multipass)
 - [Open Telekom Cloud (akyriako/devpod-provider-opentelekomcloud)](https://github.com/akyriako/devpod-provider-opentelekomcloud)


### PR DESCRIPTION
Due to the [sunsetting](https://deploy.equinix.com/blog/sunsetting-equinix-metal/) of Equinix Metal at the end of June 2026 this DevPod Provider will not be maintained anymore!