### PR TITLE
Docs(insatllation): requires libwebkit2gtk-4.1

### DIFF
--- a/docs/pages/getting-started/install.mdx
+++ b/docs/pages/getting-started/install.mdx
@@ -66,7 +66,7 @@ correct functioning of the program:
 - libwmf-0.2-7-gtk
 - libgtk-3-0
 - libwmf-dev
-- libwebkit2gtk-4.0-37
+- libwebkit2gtk-4.1-37
 - librust-openssl-sys-dev
 - librust-glib-sys-dev
 


### PR DESCRIPTION
Otherwise I was getting this error on trying to start DevPod

```
DevPod: error while loading shared libraries: libwebkit2gtk-4.1.so.0: cannot open shared object file: No such file or directory
```
