### PR TITLE
Remove flatpak binary name change

### DIFF
--- a/desktop/src-tauri/tauri-flatpak.conf.json
+++ b/desktop/src-tauri/tauri-flatpak.conf.json
@@ -1,5 +1,4 @@
 {
-  "mainBinaryName": "sh.loft.DevPod",
   "plugins": {
     "updater": {
       "active": false


### PR DESCRIPTION
The previous flatpak build failed - https://github.com/loft-sh/devpod/actions/runs/13651396251/job/38160600315

I think the simplest fix is to rename the binary in the flatpak manifest here - https://github.com/loft-sh/flathub/blob/org.loft.devpod/sh.loft.Devpod.yaml#L45

Since flatpak is the one enforcing this specific naming convention I think we should revert the name to be the same as mac and windows but rename it to `sh.loft.Devpod` for flatpak