### PR TITLE
Update flatpak manifest with correct app id

### DIFF
--- a/desktop/flatpak/DevPod.metainfo.xml
+++ b/desktop/flatpak/DevPod.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>sh.loft.Devpod</id>
+  <id>sh.loft.devpod</id>
 
   <name>Devpod</name>
   <summary>Codespaces but open-source, client-only and unopinionated: Works with any IDE and lets you use any cloud, kubernetes or just localhost docker.</summary>
@@ -25,7 +25,7 @@
     </p>
   </description>
 
-  <launchable type="desktop-id">sh.loft.Devpod.desktop</launchable>
+  <launchable type="desktop-id">sh.loft.devpod.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <image>https://devpod.sh/docs/media/devpod-architecture-2.png</image>

--- a/desktop/flatpak/sh.loft.devpod.tmpl
+++ b/desktop/flatpak/sh.loft.devpod.tmpl
@@ -44,7 +44,6 @@ modules:
       - install -Dm755 usr/bin/devpod-cli /app/bin/devpod-bin
       - install -Dm755 usr/bin/DevPod\ Desktop /app/bin/sh.loft.devpod
       - install -Dm644 DevPod.desktop /app/share/applications/sh.loft.devpod.desktop
-      - desktop-file-edit --set-key Name --set-value sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop
       - desktop-file-edit --set-key Exec --set-value sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop
       - desktop-file-edit --set-icon sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop
       - install -Dm644 usr/share/icons/hicolor/128x128/apps/DevPod\ Desktop.png /app/share/icons/hicolor/128x128/apps/sh.loft.devpod.png

--- a/desktop/flatpak/sh.loft.devpod.tmpl
+++ b/desktop/flatpak/sh.loft.devpod.tmpl
@@ -1,10 +1,10 @@
-id: sh.loft.Devpod
+id: sh.loft.devpod
 
 runtime: org.gnome.Platform
 runtime-version: '47'
 sdk: org.gnome.Sdk
 
-command: DevPod
+command: "sh.loft.devpod"
 finish-args:
   - --socket=wayland # Permission needed to show the window
   - --socket=fallback-x11 # Permission needed to show the window
@@ -26,27 +26,28 @@ modules:
     sources:
       - type: file
         url: https://github.com/loft-sh/devpod/releases/download/v${VERSION}/DevPod_${VERSION}_amd64.deb
-        sha256: ${SHA256} # This is required if you are using a remote source
-        only-arches: [x86_64] #This source is only used on x86_64 Computers
-        # This path points to the binary file which was created in the .deb bundle.
-        # Tauri also creates a folder which corresponds to the content of the unpacked .deb.
-      - type: file
-        path: devpod-wrapper
+        sha256: ${SHA256}
+        only-arches: [x86_64]
       - type: file
         url: https://github.com/loft-sh/devpod/releases/download/v${VERSION}/DevPod.desktop
         sha256: ${DESKTOP_SHA256}
       - type: file
         url: https://github.com/loft-sh/devpod/releases/download/v${VERSION}/DevPod.metainfo.xml
         sha256: ${META_SHA256}
+      - type: file
+        path: devpod-wrapper
     build-commands:
       - ar -x *.deb
       - tar -xf data.tar.gz
       - cp devpod-wrapper /app/bin/devpod-cli
       - chmod +x /app/bin/devpod-cli
       - install -Dm755 usr/bin/devpod-cli /app/bin/devpod-bin
-      - install -Dm755 usr/bin/DevPod /app/bin/DevPod
-      - install -Dm644 sh.loft.Devpod.desktop /app/share/applications/sh.loft.Devpod.desktop
-      - install -Dm644 usr/share/icons/hicolor/128x128/apps/DevPod.png /app/share/icons/hicolor/128x128/apps/sh.loft.Devpod.png
-      - install -Dm644 usr/share/icons/hicolor/32x32/apps/DevPod.png /app/share/icons/hicolor/32x32/apps/sh.loft.Devpod.png
-      - install -Dm644 usr/share/icons/hicolor/256x256@2/apps/DevPod.png /app/share/icons/hicolor/256x256@2/apps/sh.loft.Devpod.png
-      - install -Dm644 sh.loft.Devpod.metainfo.xml /app/share/metainfo/sh.loft.Devpod.metainfo.xml
+      - install -Dm755 usr/bin/DevPod\ Desktop /app/bin/sh.loft.devpod
+      - install -Dm644 DevPod.desktop /app/share/applications/sh.loft.devpod.desktop
+      - desktop-file-edit --set-key Name --set-value sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop
+      - desktop-file-edit --set-key Exec --set-value sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop
+      - desktop-file-edit --set-icon sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop
+      - install -Dm644 usr/share/icons/hicolor/128x128/apps/DevPod\ Desktop.png /app/share/icons/hicolor/128x128/apps/sh.loft.devpod.png
+      - install -Dm644 usr/share/icons/hicolor/32x32/apps/DevPod\ Desktop.png /app/share/icons/hicolor/32x32/apps/sh.loft.devpod.png
+      - install -Dm644 usr/share/icons/hicolor/256x256@2/apps/DevPod\ Desktop.png /app/share/icons/hicolor/256x256@2/apps/sh.loft.devpod.png
+      - install -Dm644 DevPod.metainfo.xml /app/share/metainfo/sh.loft.devpod.metainfo.xml

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,6 +11,7 @@
     "desktop:dev": "tauri dev --config src-tauri/tauri-dev.conf.json",
     "desktop:dev:debug": "export DEBUG=true; yarn desktop:dev",
     "desktop:build:dev": "DEBUG=true tauri build --config src-tauri/tauri-dev.conf.json",
+    "desktop:build:flatpak": "DEBUG=true tauri build --config src-tauri/tauri-flatpak.conf.json",
     "desktop:build:debug": "tauri build --debug",
     "desktop:build": "tauri build",
     "format:check": "prettier --check .",


### PR DESCRIPTION
This PR fixes DevPod.metainfo.xml that the flatpak build uses to match against the id and desktop file name to the flatpak app id. I also updated the flatpak manifest template that will be used once the flathub PR is merged.