### PR TITLE
Use 8787 instead of enumerated port

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -664,7 +664,7 @@ func startRStudioInBrowser(
 
 	// start in browser
 	logger.Infof("Starting RStudio server in browser mode at %s", targetURL)
-	extraPorts := []string{fmt.Sprintf("%s:%d", addr, port)}
+	extraPorts := []string{fmt.Sprintf("%s:%d", addr, rstudio.DefaultServerPort)}
 	return startBrowserTunnel(
 		ctx,
 		devPodConfig,


### PR DESCRIPTION
This PR fixes rstudio when port 8787 is not available locally.

Currently if port 8787 is not available locally, for example when rstudio is running with another workspace, the next free port is found. This is what we want locally, but the issue is the port in the workspace should remain 8787.