### PR TITLE
Check kube config for the namespace before using the default

### DIFF
--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -30,7 +30,7 @@ func NewKubernetesDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Lo
 		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 	// Namespace can be defined in many ways, we first check the kube config, then the provider options KUBERNETES_NAMESPACE, then failing that the default "devpod"
-	if namespace == "" || options.KubernetesNamespace != "devpod" {
+	if namespace == "" || namespace == "default" || options.KubernetesNamespace != "devpod" {
 		log.Debugf("Using Explicit Kubernetes Namespace")
 		namespace = options.KubernetesNamespace
 	}

--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -29,13 +29,12 @@ func NewKubernetesDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Lo
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
-	// If the kube config has defined a namespace, use it, otherwise stick to the default namespace
-	if namespace == "" {
+	// Namespace can be defined in many ways, we first check the kube config, then the provider options KUBERNETES_NAMESPACE, then failing that the default "devpod"
+	if namespace == "" || options.KubernetesNamespace != "devpod" {
+		log.Debugf("Using Explicit Kubernetes Namespace")
 		namespace = options.KubernetesNamespace
-		log.Debugf("Use Default Kubernetes Namespace '%s'", namespace)
-	} else {
-		log.Debugf("Use Kubernetes Namespace '%s'", namespace)
 	}
+	log.Debugf("Use Kubernetes Namespace '%s'", namespace)
 
 	return &KubernetesDriver{
 		client:    client,

--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -32,9 +32,9 @@ func NewKubernetesDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Lo
 	// If the kube config has defined a namespace, use it, otherwise stick to the default namespace
 	if namespace == "" {
 		namespace = options.KubernetesNamespace
-		log.Debugf("Use Kubernetes Namespace '%s'", namespace)
+		log.Debugf("Use Default Kubernetes Namespace '%s'", namespace)
 	} else {
-		log.Debugf("Use Default Kubernetes Namespace '%s'", options.KubernetesNamespace)
+		log.Debugf("Use Kubernetes Namespace '%s'", namespace)
 	}
 
 	return &KubernetesDriver{


### PR DESCRIPTION
When the kubernetes driver was moved into devpod, a customer discovered an issue where the PVC is always scheduled in the default namespace "devpod". This could be reproduced by deploying any workspace using a space template.

This PR fixes the issue by first checking the kube config, and if available use this namespace, instead of the default.

I tested this against a local platform with the only change being this build, using a space template. I also validated the namespace being used in the logs