### PR TITLE
Disable auto updates for linux

### DIFF
--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -85,6 +85,10 @@ impl Settings {
             error!("unable to open store {}", SETTINGS_FILE_NAME);
             return false;
         }
+        // For linux let out flathub repo provide updates
+        if cfg!(target_os = "linux") {
+            return false;
+        }
 
         store
             .unwrap()


### PR DESCRIPTION
This PR disables the auto updater window for linux since updates will be managed through our flathub repo