### PR TITLE
Check if explicit kubernetes namespace is used

### DIFF
--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -30,7 +30,7 @@ func NewKubernetesDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Lo
 		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 	// Namespace can be defined in many ways, we first check the kube config, then the provider options KUBERNETES_NAMESPACE, then failing that the default "devpod"
-	if namespace == "" || namespace == "default" || options.KubernetesNamespace != "devpod" {
+	if namespace == "" || namespace == "default" || options.KubernetesNamespace != "" {
 		log.Debugf("Using Explicit Kubernetes Namespace")
 		namespace = options.KubernetesNamespace
 	}


### PR DESCRIPTION
This PR fixes the issue of rebuilding a workspace and getting an empty directory in the PVC.

The issue was a regression from https://github.com/loft-sh/devpod/pull/1749 where the workspace when using a space template was not found. This was because the platform prepares a kube context for the space template for the kubernetes provider to use. When the inline kubernetes provider was introduced it always used the namespace defined in the options. 

The problem with the original fix was the incorrect default used to check, where devpod was used instead of an emtpy string. Since devpod can be specified as an option using KUBERNETES_NAMESPACE the fix is to only use the kube context, if the KUBERNETES_NAMESPACE option is blank.