### PR TITLE
Use WithWorkspace in setup server so tunnelserver.workspace is not nil

### DIFF
--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -54,9 +54,10 @@ func RunUpServer(ctx context.Context, reader io.Reader, writer io.WriteCloser, a
 	return tunnelServ.RunWithResult(ctx, reader, writer)
 }
 
-func RunSetupServer(ctx context.Context, reader io.Reader, writer io.WriteCloser, allowGitCredentials, allowDockerCredentials bool, mounts []*config.Mount, log log.Logger, options ...Option) (*config.Result, error) {
+func RunSetupServer(ctx context.Context, reader io.Reader, writer io.WriteCloser, allowGitCredentials, allowDockerCredentials bool, mounts []*config.Mount, workspace *provider2.Workspace, log log.Logger, options ...Option) (*config.Result, error) {
 	opts := append(options, []Option{
 		WithMounts(mounts),
+		WithWorkspace(workspace),
 		WithAllowGitCredentials(allowGitCredentials),
 		WithAllowDockerCredentials(allowDockerCredentials),
 		WithAllowKubeConfig(true),

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -132,6 +132,7 @@ func (r *runner) setupContainer(
 			r.WorkspaceConfig.Agent.InjectGitCredentials != "false",
 			r.WorkspaceConfig.Agent.InjectDockerCredentials != "false",
 			config.GetMounts(result),
+			r.WorkspaceConfig.Workspace,
 			r.Log,
 			tunnelserver.WithPlatformOptions(&r.WorkspaceConfig.CLIOptions.Platform),
 		)


### PR DESCRIPTION
Fixes https://github.com/loft-sh/devpod/issues/1719

WIP, this PR fixed the segment fault but still results in a return code 128 (un auth) for the git operations. I can see the agent forwarding is working, but perhaps it is due to the `su -c` we use to run the life cycle hook