### PR TITLE
fix call fmt.Errorf with wrong error

### DIFF
--- a/pkg/devcontainer/config/userenvprobe.go
+++ b/pkg/devcontainer/config/userenvprobe.go
@@ -116,7 +116,7 @@ func doProbe(ctx context.Context, userEnvProbe UserEnvProbe, preferredShell []st
 		}
 		retEnv[tokens[0]] = tokens[1]
 	}
-	if scanner.Err() != nil {
+	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("scan shell output: %w", err)
 	}
 	delete(retEnv, "PWD")


### PR DESCRIPTION
the origin err is nil value now,
should use the checked scanner.Err()