### PR TITLE
fix: GHA warnings

### DIFF
--- a/.github/workflows/build-devcontainer-image.yaml
+++ b/.github/workflows/build-devcontainer-image.yaml
@@ -28,11 +28,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Prepare DevPod
         run: |


### PR DESCRIPTION
Update versions of below reusable actions:
- docker/setup-qemu-action@v3
- docker/setup-buildx-action@v3

Update will fix below Warnings:
- build-and-pushThe `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- build-and-pushThe `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands