### PR TITLE
Allow manual deb file to be installed

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -445,7 +445,10 @@ func (cmd *SetupContainerCmd) installIDE(setupInfo *config.Result, ide *provider
 	case string(config2.IDEJupyterNotebook):
 		return jupyter.NewJupyterNotebookServer(setupInfo.SubstitutionContext.ContainerWorkspaceFolder, config.GetRemoteUser(setupInfo), ide.Options, log).Install()
 	case string(config2.IDERStudio):
-		return rstudio.NewRStudioServer(setupInfo.SubstitutionContext.ContainerWorkspaceFolder, config.GetRemoteUser(setupInfo), ide.Options, log).Install()
+		err := rstudio.NewRStudioServer(setupInfo.SubstitutionContext.ContainerWorkspaceFolder, config.GetRemoteUser(setupInfo), ide.Options, log).Install()
+		if err != nil {
+			log.Errorf("could not install rstudio with error: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR updates the rstudio integration to check for the download directory `/var/devpod/rstudio-server` first for the .deb file. If it exists it skips the download and installs it.

DO NOT MERGE, how do I merge this into v0.6.15?