### PR TITLE
Fix clipboard in xterm

### DIFF
--- a/desktop/src/components/Terminal/Terminal.tsx
+++ b/desktop/src/components/Terminal/Terminal.tsx
@@ -74,10 +74,7 @@ export const Terminal = forwardRef<TTerminalRef, TTerminalProps>(function T(
       terminalRef.current = terminal
 
       terminal.attachCustomKeyEventHandler(event => {
-        if (event.type === "keydown" && event.key === "c" && event.ctrlKey) {
-          return false;
-        }
-        return true;
+        return !(event.type === "keydown" && event.key === "c" && event.ctrlKey);
       });
 
       const loadAddon = <T extends ITerminalAddon>(

--- a/desktop/src/components/Terminal/Terminal.tsx
+++ b/desktop/src/components/Terminal/Terminal.tsx
@@ -73,11 +73,12 @@ export const Terminal = forwardRef<TTerminalRef, TTerminalProps>(function T(
       })
       terminalRef.current = terminal
 
-      terminal.onKey((key) => {
-        if (terminal.hasSelection() && key.domEvent.ctrlKey && key.domEvent.key === "c") {
-          document.execCommand("copy")
+      terminal.attachCustomKeyEventHandler(event => {
+        if (event.type === "keydown" && event.key === "c" && event.ctrlKey) {
+          return false;
         }
-      })
+        return true;
+      });
 
       const loadAddon = <T extends ITerminalAddon>(
         AddonClass: new () => T,


### PR DESCRIPTION
This PR fixes copy and pasting from the desktop app logs.

The issue was a known xterm limitation in that ctrl +c is mapped to the terminals key handlers. Previously we relied on document.execCommand("copy") but this is deprecated in web view. Looking at the dependency GH issues https://github.com/xtermjs/xterm.js/issues/2478 and https://github.com/xtermjs/xterm.js/issues/292 a user offered an alternative solution which is to use `attachCustomKeyEventHandler` and return false on Ctrl + C to prevent the terminal key binding being used on ctrl +c.

https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand