### PR TITLE
Support lifecycle hooks in devcontainer features

### DIFF
--- a/pkg/devcontainer/config/feature.go
+++ b/pkg/devcontainer/config/feature.go
@@ -61,8 +61,7 @@ type FeatureConfig struct {
 	// Container environment variables.
 	ContainerEnv map[string]string `json:"containerEnv,omitempty"`
 
-	// Tool-specific configuration. Each tool should use a JSON object subproperty with a unique name to group its customizations.
-	Customizations map[string]interface{} `json:"customizations,omitempty"`
+	DevContainerActions `json:",inline"`
 
 	// Origin is the path where the feature was loaded from
 	Origin string `json:"-"`

--- a/pkg/devcontainer/metadata/metadata.go
+++ b/pkg/devcontainer/metadata/metadata.go
@@ -39,7 +39,12 @@ func FeatureConfigToImageMetadata(feature *config.FeatureConfig) *config.ImageMe
 	return &config.ImageMetadata{
 		Entrypoint: feature.Entrypoint,
 		DevContainerActions: config.DevContainerActions{
-			Customizations: feature.Customizations,
+			OnCreateCommand:      feature.OnCreateCommand,
+			UpdateContentCommand: feature.UpdateContentCommand,
+			PostCreateCommand:    feature.PostCreateCommand,
+			PostStartCommand:     feature.PostStartCommand,
+			PostAttachCommand:    feature.PostAttachCommand,
+			Customizations:       feature.Customizations,
 		},
 		NonComposeBase: config.NonComposeBase{
 			Mounts:      feature.Mounts,


### PR DESCRIPTION
Parse and save lifecycle hooks from features into image metadata. Once available as metadata, it seems like they are correctly used already.

Tests are missing, I do not have the capacity to add them. Would appreciate maintainer help with that.

Fixes: #1880