### PR TITLE
Correct package for Debian 13

### DIFF
--- a/docs/pages/getting-started/install.mdx
+++ b/docs/pages/getting-started/install.mdx
@@ -36,7 +36,7 @@ Make sure you have the following dependencies installed for the Appimage to work
 
 - glibc version 2.35+
 - fuse2, fuse2 libraries, libopengl, libfribidi, libegl, libxgl
-    - `sudo apt-get install fuse libfuse2 libopengl0 libfribidi0 libgles2-mesa`
+    - `sudo apt-get install fuse libfuse2 libopengl0 libfribidi0 libgles2-mesa-dev`
     - `sudo dnf install fuse fuse-libs libglvnd-egl libglvnd-opengl libglvnd-glx harfbuzz fontconfig fribidi libthai`
     - `sudo zypper in fuse libfuse2 libharfbuzz0 libfribidi0 libthai0`
 


### PR DESCRIPTION
Otherwise apt-get complains that there's no matching package, at least on Debian 13 (Trixie):

```sh
$ sudo apt-get install fuse libfuse2 libopengl0 libfribidi0 libgles2-mesa
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'libfuse2t64' instead of 'libfuse2'
E: Unable to locate package libgles2-mesa
```