### PR TITLE
Clarify SSH session requirement for port forwarding

### DIFF
--- a/docs/pages/troubleshooting/troubleshooting.mdx
+++ b/docs/pages/troubleshooting/troubleshooting.mdx
@@ -18,4 +18,4 @@ exec $SHELL -c 'exec /Applications/DevPod.app/Contents/MacOS/DevPod'
 ### Port forwarding not working when NOT using an ide
 
 DevPod relies on an active SSH session to perform port forwarding to the local host. When running DevPod without an IDE, such as `--ide none`,
-an active SSH session needs to be open using `devpod ssh {workspace}`.
+an active SSH session needs to be open using `devpod ssh {workspace}` (unless you are specifying forwarded ports using docker compose).


### PR DESCRIPTION
Clarified the requirement for an active SSH session when using DevPod without an IDE, mentioning the option to specify forwarded ports using Docker Compose.

Related:https://fabiorehm.com/blog/2025/11/11/devpod-ssh-devcontainers/#port-forwarding-choose-your-approach